### PR TITLE
Feat: 시간 필드들 KST로 변환하여 응답

### DIFF
--- a/backend/src/main/java/backend/capstone/domain/bookmarkplace/controller/BookmarkPlaceControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/bookmarkplace/controller/BookmarkPlaceControllerSpec.java
@@ -27,7 +27,7 @@ public interface BookmarkPlaceControllerSpec {
         description = """
             type 필드의 값은 HOME/COMPANY/SCHOOL/ETC 중 하나를 선택해 주세요.<br>
             카카오 장소 검색 api에서 받은 longitude와 latitude 값을 요청값에 넣어주세요.<br>
-            이미 type이 HOME인 즐겨찾기 장소가 존재하고, 요청 type도 HOME인 경우 예외가 발생합니다. (집주소 중복 등록 방지)
+            이미 type이 HOME인 즐찾 장소가 존재하는데, HOME type 즐찾 장소를 등록하려는 경우 예외가 발생합니다. (집주소 중복 등록 방지)
             """
     )
     BookmarkPlaceCreateResponse createBookmarkPlace(

--- a/backend/src/main/java/backend/capstone/domain/bookmarkplace/controller/BookmarkPlaceControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/bookmarkplace/controller/BookmarkPlaceControllerSpec.java
@@ -26,7 +26,8 @@ public interface BookmarkPlaceControllerSpec {
         summary = "즐겨찾기 장소 등록 API",
         description = """
             type 필드의 값은 HOME/COMPANY/SCHOOL/ETC 중 하나를 선택해 주세요.<br>
-            카카오 장소 검색 api에서 받은 longitude와 latitude 값을 요청값에 넣어주세요.
+            카카오 장소 검색 api에서 받은 longitude와 latitude 값을 요청값에 넣어주세요.<br>
+            이미 type이 HOME인 즐겨찾기 장소가 존재하고, 요청 type도 HOME인 경우 예외가 발생합니다. (집주소 중복 등록 방지)
             """
     )
     BookmarkPlaceCreateResponse createBookmarkPlace(
@@ -38,7 +39,8 @@ public interface BookmarkPlaceControllerSpec {
         summary = "즐겨찾기 장소 수정 API",
         description = """
             type 필드의 값은 HOME/COMPANY/SCHOOL/ETC 중 하나를 선택해 주세요.<br>
-            해당 api는 put 메서드로 해당 BookmarkPlace의 모든 필드들을 덮어씌워서 저장합니다. 변경되지 않은 필드도 원래값들을 넣어주세요.
+            해당 api는 put 메서드로 해당 BookmarkPlace의 모든 필드들을 덮어씌워서 저장합니다. 변경되지 않은 필드도 원래값들을 넣어주세요.<br>
+            type이 HOME인 즐겨찾기 장소가 존재하는데, 기존 type에서 HOME으로 변경 요청이 들어온 경우 예외가 발생합니다. (집주소 중복 등록 방지)<br>
             """
     )
     BookmarkPlaceUpdateResponse updateBookmarkPlace(

--- a/backend/src/main/java/backend/capstone/domain/bookmarkplace/exception/BookmarkPlaceErrorCode.java
+++ b/backend/src/main/java/backend/capstone/domain/bookmarkplace/exception/BookmarkPlaceErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum BookmarkPlaceErrorCode implements ErrorCode {
 
-    BOOKMARK_PLACE_NOT_FOUND("즐겨찾기 장소를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    BOOKMARK_PLACE_NOT_FOUND("즐겨찾기 장소를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    HOME_BOOKMARK_PLACE_ALREADY_EXISTS("HOME 타입 즐겨찾기 장소는 1개만 등록할 수 있습니다.", HttpStatus.CONFLICT);
 
     private final String message;
     private final HttpStatus status;

--- a/backend/src/main/java/backend/capstone/domain/bookmarkplace/repository/BookmarkPlaceRepository.java
+++ b/backend/src/main/java/backend/capstone/domain/bookmarkplace/repository/BookmarkPlaceRepository.java
@@ -1,6 +1,7 @@
 package backend.capstone.domain.bookmarkplace.repository;
 
 import backend.capstone.domain.bookmarkplace.entity.BookmarkPlace;
+import backend.capstone.domain.bookmarkplace.entity.BookmarkPlaceType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,4 +25,7 @@ public interface BookmarkPlaceRepository extends JpaRepository<BookmarkPlace, Lo
         """)
     Optional<BookmarkPlace> findByIdAndUserId(@Param("bookmarkPlaceId") Long bookmarkPlaceId,
         @Param("userId") Long userId);
+
+    //TODO: JPQL로 변경
+    boolean existsByUserIdAndType(Long userId, BookmarkPlaceType type);
 }

--- a/backend/src/main/java/backend/capstone/domain/bookmarkplace/service/BookmarkPlaceService.java
+++ b/backend/src/main/java/backend/capstone/domain/bookmarkplace/service/BookmarkPlaceService.java
@@ -6,13 +6,13 @@ import backend.capstone.domain.bookmarkplace.dto.BookmarkPlaceListResponse;
 import backend.capstone.domain.bookmarkplace.dto.BookmarkPlaceUpdateRequest;
 import backend.capstone.domain.bookmarkplace.dto.BookmarkPlaceUpdateResponse;
 import backend.capstone.domain.bookmarkplace.entity.BookmarkPlace;
+import backend.capstone.domain.bookmarkplace.entity.BookmarkPlaceType;
 import backend.capstone.domain.bookmarkplace.exception.BookmarkPlaceErrorCode;
 import backend.capstone.domain.bookmarkplace.mapper.BookmarkPlaceMapper;
 import backend.capstone.domain.bookmarkplace.repository.BookmarkPlaceRepository;
 import backend.capstone.domain.user.entity.User;
 import backend.capstone.domain.user.service.UserService;
 import backend.capstone.global.exception.BusinessException;
-import jakarta.transaction.TransactionScoped;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,6 +28,7 @@ public class BookmarkPlaceService {
     @Transactional
     public BookmarkPlaceCreateResponse createBookmarkPlace(Long userId,
         BookmarkPlaceCreateRequest request) {
+        validateHomeBookmarkPlaceCreation(userId, request.type());
         User user = userService.findById(userId);
         BookmarkPlace bookmarkPlace = BookmarkPlaceMapper.toEntity(user, request);
         BookmarkPlace savedBookmarkPlace = bookmarkPlaceRepository.save(bookmarkPlace);
@@ -42,6 +43,8 @@ public class BookmarkPlaceService {
                 userId)
             .orElseThrow(
                 () -> new BusinessException(BookmarkPlaceErrorCode.BOOKMARK_PLACE_NOT_FOUND));
+
+        validateHomeBookmarkPlaceUpdate(userId, bookmarkPlace, request.type());
 
         bookmarkPlace.update(request.type(), request.placeName(), request.roadAddress(),
             request.latitude(), request.longitude()
@@ -71,5 +74,21 @@ public class BookmarkPlaceService {
     @Transactional(readOnly = true)
     public List<BookmarkPlace> getBookmarkPlaceByUserId(Long userId) {
         return bookmarkPlaceRepository.findByUserIdOrderByIdAsc(userId);
+    }
+
+    private void validateHomeBookmarkPlaceCreation(Long userId, BookmarkPlaceType type) {
+        if (type == BookmarkPlaceType.HOME
+            && bookmarkPlaceRepository.existsByUserIdAndType(userId, BookmarkPlaceType.HOME)) {
+            throw new BusinessException(BookmarkPlaceErrorCode.HOME_BOOKMARK_PLACE_ALREADY_EXISTS);
+        }
+    }
+
+    private void validateHomeBookmarkPlaceUpdate(Long userId, BookmarkPlace bookmarkPlace,
+        BookmarkPlaceType requestedType) {
+        if (requestedType == BookmarkPlaceType.HOME
+            && bookmarkPlace.getType() != BookmarkPlaceType.HOME
+            && bookmarkPlaceRepository.existsByUserIdAndType(userId, BookmarkPlaceType.HOME)) {
+            throw new BusinessException(BookmarkPlaceErrorCode.HOME_BOOKMARK_PLACE_ALREADY_EXISTS);
+        }
     }
 }

--- a/backend/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteDetailResponse.java
+++ b/backend/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteDetailResponse.java
@@ -1,7 +1,7 @@
 package backend.capstone.domain.dayroute.dto;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import lombok.Builder;
 
@@ -18,7 +18,7 @@ public record DayRouteDetailResponse(
 ) {
 
     public record GpsPointItem(
-        LocalDateTime recordedAt,
+        Instant recordedAt,
         double latitude,
         double longitude
     ) {

--- a/backend/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteDetailResponse.java
+++ b/backend/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteDetailResponse.java
@@ -1,7 +1,8 @@
 package backend.capstone.domain.dayroute.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
-import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.Builder;
 
@@ -18,7 +19,8 @@ public record DayRouteDetailResponse(
 ) {
 
     public record GpsPointItem(
-        Instant recordedAt,
+        @Schema(example = "2026-04-29T13:32:43.059+09:00")
+        OffsetDateTime recordedAt,
         double latitude,
         double longitude
     ) {

--- a/backend/src/main/java/backend/capstone/domain/dayroute/dto/GpsPointBatchUploadRequest.java
+++ b/backend/src/main/java/backend/capstone/domain/dayroute/dto/GpsPointBatchUploadRequest.java
@@ -2,7 +2,7 @@ package backend.capstone.domain.dayroute.dto;
 
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 public record GpsPointBatchUploadRequest(
@@ -12,7 +12,7 @@ public record GpsPointBatchUploadRequest(
 ) {
 
     public record GpsPointRequest(
-        LocalDateTime recordedAt,
+        Instant recordedAt,
         @DecimalMin(value = "-90.0") @DecimalMax(value = "90.0") double latitude,
         @DecimalMin(value = "-180.0") @DecimalMax(value = "180.0") double longitude
     ) {

--- a/backend/src/main/java/backend/capstone/domain/dayroute/entity/DayRoute.java
+++ b/backend/src/main/java/backend/capstone/domain/dayroute/entity/DayRoute.java
@@ -15,8 +15,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -46,9 +46,9 @@ public class DayRoute {
 
     private LocalDate date;
 
-    private LocalDateTime startTime;
+    private Instant startTime;
 
-    private LocalDateTime endTime;
+    private Instant endTime;
 
     private double totalDistance;
 
@@ -76,7 +76,7 @@ public class DayRoute {
     // stay 분석 flag
     private boolean analysisNeeded;
 
-    private LocalDateTime lastAnalyzedAt;
+    private Instant lastAnalyzedAt;
 
     @Enumerated(EnumType.STRING)
     private AnalysisStatus analysisStatus;
@@ -89,7 +89,7 @@ public class DayRoute {
         analysisStatus = AnalysisStatus.IDLE;
     }
 
-    public void updateTime(LocalDateTime startTime, LocalDateTime endTime) {
+    public void updateTime(Instant startTime, Instant endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
     }
@@ -138,7 +138,7 @@ public class DayRoute {
         this.analysisStatus = AnalysisStatus.IDLE;
     }
 
-    public void completeAnalysis(LocalDateTime recordedAt) {
+    public void completeAnalysis(Instant recordedAt) {
         lastAnalyzedAt = recordedAt;
         markIdleAnalysis();
     }

--- a/backend/src/main/java/backend/capstone/domain/dayroute/mapper/DayRouteMapper.java
+++ b/backend/src/main/java/backend/capstone/domain/dayroute/mapper/DayRouteMapper.java
@@ -5,6 +5,7 @@ import backend.capstone.domain.dayroute.dto.DayRouteMonthlyResponse;
 import backend.capstone.domain.dayroute.entity.DayRoute;
 import backend.capstone.domain.gpspoint.entity.GpsPoint;
 import backend.capstone.domain.user.entity.User;
+import backend.capstone.global.util.KstDateTimeUtils;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
@@ -36,7 +37,7 @@ public class DayRouteMapper {
 //            .pathPointCount(dayRoute.getPathPointCount())
             .gpsPoints(gpsPoints.stream()
                 .map(gp -> new DayRouteDetailResponse.GpsPointItem(
-                    gp.getRecordedAt(),
+                    KstDateTimeUtils.toKstOffsetDateTime(gp.getRecordedAt()),
                     gp.getLatitude(),
                     gp.getLongitude()
                 ))

--- a/backend/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
+++ b/backend/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
@@ -8,6 +8,7 @@ import backend.capstone.domain.dayroute.repository.DayRouteRepository;
 import backend.capstone.domain.place.repository.PlaceRepository;
 import backend.capstone.domain.user.service.UserService;
 import backend.capstone.global.exception.BusinessException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -93,7 +94,7 @@ public class DayRouteService {
     }
 
     @Transactional
-    public void updateTime(DayRoute dayRoute, LocalDateTime startTime, LocalDateTime endTime) {
+    public void updateTime(DayRoute dayRoute, Instant startTime, Instant endTime) {
         dayRoute.updateTime(startTime, endTime);
     }
 

--- a/backend/src/main/java/backend/capstone/domain/gpspoint/dto/GpsPointRecordedAtRange.java
+++ b/backend/src/main/java/backend/capstone/domain/gpspoint/dto/GpsPointRecordedAtRange.java
@@ -1,10 +1,10 @@
 package backend.capstone.domain.gpspoint.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record GpsPointRecordedAtRange(
-    LocalDateTime startTime,
-    LocalDateTime endTime
+    Instant startTime,
+    Instant endTime
 ) {
 
 }

--- a/backend/src/main/java/backend/capstone/domain/gpspoint/entity/GpsPoint.java
+++ b/backend/src/main/java/backend/capstone/domain/gpspoint/entity/GpsPoint.java
@@ -11,7 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -43,5 +43,5 @@ public class GpsPoint {
 
     private double longitude;
 
-    private LocalDateTime recordedAt;
+    private Instant recordedAt;
 }

--- a/backend/src/main/java/backend/capstone/domain/gpspoint/repository/GpsPointRepository.java
+++ b/backend/src/main/java/backend/capstone/domain/gpspoint/repository/GpsPointRepository.java
@@ -3,7 +3,7 @@ package backend.capstone.domain.gpspoint.repository;
 import backend.capstone.domain.dayroute.entity.DayRoute;
 import backend.capstone.domain.gpspoint.dto.GpsPointRecordedAtRange;
 import backend.capstone.domain.gpspoint.entity.GpsPoint;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -39,7 +39,7 @@ public interface GpsPointRepository extends
         """)
     List<GpsPoint> findNewPointsAfterCursor(
         @Param("dayRoute") DayRoute dayRoute,
-        @Param("lastRecordedAt") LocalDateTime lastRecordedAt
+        @Param("lastRecordedAt") Instant lastRecordedAt
     );
 
     List<GpsPoint> findByDayRouteOrderByRecordedAtAsc(@Param("dayRoute") DayRoute dayRoute);

--- a/backend/src/main/java/backend/capstone/domain/gpspoint/service/GpsPointService.java
+++ b/backend/src/main/java/backend/capstone/domain/gpspoint/service/GpsPointService.java
@@ -6,7 +6,7 @@ import backend.capstone.domain.dayroute.entity.DayRoute;
 import backend.capstone.domain.gpspoint.dto.GpsPointRecordedAtRange;
 import backend.capstone.domain.gpspoint.entity.GpsPoint;
 import backend.capstone.domain.gpspoint.repository.GpsPointRepository;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -51,7 +51,7 @@ public class GpsPointService {
     }
 
     @Transactional(readOnly = true)
-    public List<GpsPoint> getNewPoints(DayRoute dayRoute, LocalDateTime lastAnalyzedAt) {
+    public List<GpsPoint> getNewPoints(DayRoute dayRoute, Instant lastAnalyzedAt) {
         if (lastAnalyzedAt == null) {
             return gpsPointRepository.findByDayRouteOrderByRecordedAtAsc(dayRoute);
         }

--- a/backend/src/main/java/backend/capstone/domain/ongoingstay/entity/OngoingStay.java
+++ b/backend/src/main/java/backend/capstone/domain/ongoingstay/entity/OngoingStay.java
@@ -12,7 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -38,9 +38,9 @@ public class OngoingStay extends BaseTimeEntity {
     @JoinColumn(name = "end_point_id")
     private GpsPoint lastPoint;
 
-    private LocalDateTime startTime;
+    private Instant startTime;
 
-    private LocalDateTime lastTime;
+    private Instant lastTime;
 
     private double centerLatitude;
 
@@ -79,7 +79,7 @@ public class OngoingStay extends BaseTimeEntity {
         return Duration.between(startTime, lastTime).toMinutes();
     }
 
-    public void updateLastTime(LocalDateTime lastTime) {
+    public void updateLastTime(Instant lastTime) {
         this.lastTime = lastTime;
     }
 }

--- a/backend/src/main/java/backend/capstone/domain/ongoingstay/service/StayAnalysisService.java
+++ b/backend/src/main/java/backend/capstone/domain/ongoingstay/service/StayAnalysisService.java
@@ -5,13 +5,14 @@ import backend.capstone.domain.dayroute.entity.DayRoute;
 import backend.capstone.domain.dayroute.service.DayRouteService;
 import backend.capstone.domain.gpspoint.entity.GpsPoint;
 import backend.capstone.domain.gpspoint.service.GpsPointService;
+import backend.capstone.domain.kakaoplace.dto.SearchResultByCategoryAndCoord;
 import backend.capstone.domain.kakaoplace.service.KakaoSearchByCategoryService;
 import backend.capstone.domain.ongoingstay.entity.OngoingStay;
 import backend.capstone.domain.ongoingstay.repository.OngoingStayRepository;
-import backend.capstone.domain.kakaoplace.dto.SearchResultByCategoryAndCoord;
 import backend.capstone.domain.place.service.PlaceService;
 import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class StayAnalysisService {
 
     private static final int STAY_RADIUS_METER = 50;
     private static final int STAY_MIN_DURATION_MINUTE = 15;
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final OngoingStayRepository ongoingStayRepository;
     private final GpsPointService gpsPointService;
@@ -109,9 +111,12 @@ public class StayAnalysisService {
             return;
         }
 
-        LocalDateTime dayRouteEndTime = dayRouteService.getDayRouteEndTime(dayRoute);
+        Instant dayRouteEndTime = dayRouteService.getDayRouteEndTime(dayRoute)
+            .atZone(KST_ZONE_ID)
+            .toInstant();
+
         // 아직 이 dayRoute의 종료 기준 시각이 지나지 않았으면 아무것도 하지 않음
-        if (LocalDateTime.now().isBefore(dayRouteEndTime)) {
+        if (Instant.now().isBefore(dayRouteEndTime)) {
             return;
         }
 

--- a/backend/src/main/java/backend/capstone/domain/place/dto/PlaceAddResponse.java
+++ b/backend/src/main/java/backend/capstone/domain/place/dto/PlaceAddResponse.java
@@ -2,7 +2,8 @@ package backend.capstone.domain.place.dto;
 
 import backend.capstone.domain.bookmarkplace.entity.BookmarkPlaceType;
 import backend.capstone.domain.place.entity.PlaceSource;
-import java.time.Instant;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.OffsetDateTime;
 import lombok.Builder;
 
 @Builder
@@ -15,7 +16,9 @@ public record PlaceAddResponse(
     double latitude,
     double longitude,
     int orderIndex,
-    Instant startTime,
-    Instant endTime
+    @Schema(example = "2026-04-29T13:32:43.059+09:00")
+    OffsetDateTime startTime,
+    @Schema(example = "2026-04-29T13:32:43.059+09:00")
+    OffsetDateTime endTime
 ) {
 }

--- a/backend/src/main/java/backend/capstone/domain/place/dto/PlaceAddResponse.java
+++ b/backend/src/main/java/backend/capstone/domain/place/dto/PlaceAddResponse.java
@@ -2,7 +2,7 @@ package backend.capstone.domain.place.dto;
 
 import backend.capstone.domain.bookmarkplace.entity.BookmarkPlaceType;
 import backend.capstone.domain.place.entity.PlaceSource;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.Builder;
 
 @Builder
@@ -15,7 +15,7 @@ public record PlaceAddResponse(
     double latitude,
     double longitude,
     int orderIndex,
-    LocalDateTime startTime,
-    LocalDateTime endTime
+    Instant startTime,
+    Instant endTime
 ) {
 }

--- a/backend/src/main/java/backend/capstone/domain/place/dto/PlaceItem.java
+++ b/backend/src/main/java/backend/capstone/domain/place/dto/PlaceItem.java
@@ -3,7 +3,7 @@ package backend.capstone.domain.place.dto;
 import backend.capstone.domain.bookmarkplace.entity.BookmarkPlaceType;
 import backend.capstone.domain.place.entity.PlaceSource;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.Instant;
+import java.time.OffsetDateTime;
 import lombok.Builder;
 
 @Builder
@@ -32,10 +32,10 @@ public record PlaceItem(
     @Schema(example = "1", description = "일정 내 장소 순서")
     int orderIndex,
 
-    @Schema(example = "09:30:00", description = "장소 체류 시작 시간")
-    Instant startTime,
+    @Schema(example = "2026-04-29T13:32:43.059+09:00", description = "장소 체류 시작 시간")
+    OffsetDateTime startTime,
 
-    @Schema(example = "10:15:00", description = "장소 체류 종료 시간")
-    Instant endTime
+    @Schema(example = "2026-04-29T13:32:43.059+09:00", description = "장소 체류 종료 시간")
+    OffsetDateTime endTime
 ) {
 }

--- a/backend/src/main/java/backend/capstone/domain/place/dto/PlaceItem.java
+++ b/backend/src/main/java/backend/capstone/domain/place/dto/PlaceItem.java
@@ -3,7 +3,7 @@ package backend.capstone.domain.place.dto;
 import backend.capstone.domain.bookmarkplace.entity.BookmarkPlaceType;
 import backend.capstone.domain.place.entity.PlaceSource;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.Builder;
 
 @Builder
@@ -33,9 +33,9 @@ public record PlaceItem(
     int orderIndex,
 
     @Schema(example = "09:30:00", description = "장소 체류 시작 시간")
-    LocalDateTime startTime,
+    Instant startTime,
 
     @Schema(example = "10:15:00", description = "장소 체류 종료 시간")
-    LocalDateTime endTime
+    Instant endTime
 ) {
 }

--- a/backend/src/main/java/backend/capstone/domain/place/dto/PlaceUpdateResponse.java
+++ b/backend/src/main/java/backend/capstone/domain/place/dto/PlaceUpdateResponse.java
@@ -2,7 +2,8 @@ package backend.capstone.domain.place.dto;
 
 import backend.capstone.domain.bookmarkplace.entity.BookmarkPlaceType;
 import backend.capstone.domain.place.entity.PlaceSource;
-import java.time.Instant;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.OffsetDateTime;
 import lombok.Builder;
 
 @Builder
@@ -13,7 +14,9 @@ public record PlaceUpdateResponse(
     BookmarkPlaceType type,
     double latitude,
     double longitude,
-    Instant startTime,
-    Instant endTime
+    @Schema(example = "2026-04-29T13:32:43.059+09:00")
+    OffsetDateTime startTime,
+    @Schema(example = "2026-04-29T13:32:43.059+09:00")
+    OffsetDateTime endTime
 ) {
 }

--- a/backend/src/main/java/backend/capstone/domain/place/dto/PlaceUpdateResponse.java
+++ b/backend/src/main/java/backend/capstone/domain/place/dto/PlaceUpdateResponse.java
@@ -2,7 +2,7 @@ package backend.capstone.domain.place.dto;
 
 import backend.capstone.domain.bookmarkplace.entity.BookmarkPlaceType;
 import backend.capstone.domain.place.entity.PlaceSource;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.Builder;
 
 @Builder
@@ -13,7 +13,7 @@ public record PlaceUpdateResponse(
     BookmarkPlaceType type,
     double latitude,
     double longitude,
-    LocalDateTime startTime,
-    LocalDateTime endTime
+    Instant startTime,
+    Instant endTime
 ) {
 }

--- a/backend/src/main/java/backend/capstone/domain/place/entity/Place.java
+++ b/backend/src/main/java/backend/capstone/domain/place/entity/Place.java
@@ -15,7 +15,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,16 +54,16 @@ public class Place extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private PlaceSource source;
 
-    private LocalDateTime startTime;
+    private Instant startTime;
 
-    private LocalDateTime endTime;
+    private Instant endTime;
 
     @Enumerated(EnumType.STRING)
     private BookmarkPlaceType type;
 
     @Builder
     Place(DayRoute dayRoute, String roadAddress, String name, double latitude, double longitude,
-        int orderIndex, PlaceSource source, LocalDateTime startTime, LocalDateTime endTime) {
+        int orderIndex, PlaceSource source, Instant startTime, Instant endTime) {
         this.dayRoute = dayRoute;
         this.roadAddress = roadAddress;
         this.name = name;

--- a/backend/src/main/java/backend/capstone/domain/place/mapper/PlaceMapper.java
+++ b/backend/src/main/java/backend/capstone/domain/place/mapper/PlaceMapper.java
@@ -9,6 +9,7 @@ import backend.capstone.domain.place.dto.PlaceListResponse;
 import backend.capstone.domain.place.dto.PlaceUpdateResponse;
 import backend.capstone.domain.place.entity.Place;
 import backend.capstone.domain.place.entity.PlaceSource;
+import backend.capstone.global.util.KstDateTimeUtils;
 import java.time.Instant;
 import java.util.List;
 import lombok.NoArgsConstructor;
@@ -39,8 +40,8 @@ public class PlaceMapper {
             .latitude(place.getLatitude())
             .longitude(place.getLongitude())
             .orderIndex(place.getOrderIndex())
-            .startTime(place.getStartTime())
-            .endTime(place.getEndTime())
+            .startTime(KstDateTimeUtils.toKstOffsetDateTime(place.getStartTime()))
+            .endTime(KstDateTimeUtils.toKstOffsetDateTime(place.getEndTime()))
             .build();
     }
 
@@ -54,8 +55,8 @@ public class PlaceMapper {
             .latitude(place.getLatitude())
             .longitude(place.getLongitude())
             .orderIndex(place.getOrderIndex())
-            .startTime(place.getStartTime())
-            .endTime(place.getEndTime())
+            .startTime(KstDateTimeUtils.toKstOffsetDateTime(place.getStartTime()))
+            .endTime(KstDateTimeUtils.toKstOffsetDateTime(place.getEndTime()))
             .build();
     }
 
@@ -78,8 +79,8 @@ public class PlaceMapper {
             .type(place.getType())
             .latitude(place.getLatitude())
             .longitude(place.getLongitude())
-            .startTime(place.getStartTime())
-            .endTime(place.getEndTime())
+            .startTime(KstDateTimeUtils.toKstOffsetDateTime(place.getStartTime()))
+            .endTime(KstDateTimeUtils.toKstOffsetDateTime(place.getEndTime()))
             .build();
     }
 

--- a/backend/src/main/java/backend/capstone/domain/place/mapper/PlaceMapper.java
+++ b/backend/src/main/java/backend/capstone/domain/place/mapper/PlaceMapper.java
@@ -9,7 +9,7 @@ import backend.capstone.domain.place.dto.PlaceListResponse;
 import backend.capstone.domain.place.dto.PlaceUpdateResponse;
 import backend.capstone.domain.place.entity.Place;
 import backend.capstone.domain.place.entity.PlaceSource;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import lombok.NoArgsConstructor;
 
@@ -87,8 +87,8 @@ public class PlaceMapper {
         DayRoute dayRoute,
         SearchResultByCategoryAndCoord searchResult,
         int orderIndex,
-        LocalDateTime startTime,
-        LocalDateTime endTime
+        Instant startTime,
+        Instant endTime
     ) {
         return Place.builder()
             .dayRoute(dayRoute)
@@ -109,8 +109,8 @@ public class PlaceMapper {
         double stayLatitude,
         double stayLongitude,
         int orderIndex,
-        LocalDateTime startTime,
-        LocalDateTime endTime
+        Instant startTime,
+        Instant endTime
     ) {
         return Place.builder()
             .dayRoute(dayRoute)

--- a/backend/src/main/java/backend/capstone/global/util/KstDateTimeUtils.java
+++ b/backend/src/main/java/backend/capstone/global/util/KstDateTimeUtils.java
@@ -1,0 +1,20 @@
+package backend.capstone.global.util;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class KstDateTimeUtils {
+
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    public static OffsetDateTime toKstOffsetDateTime(Instant instant) {
+        if (instant == null) {
+            return null;
+        }
+        return instant.atZone(KST_ZONE_ID).toOffsetDateTime();
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#11 

## 🪐 작업 내용
### 좌표 업로드 API에서 좌표의 recordedAt을 UTC 시간으로 강제
```json
{
  "distance": 0,
  "gpsPoints": [
    {
      "recordedAt": "2026-04-30T02:43:52.138Z",
      "latitude": 90,
      "longitude": 180
    }
  ]
}
```
서버로 업로드하는 시간 필드는 모두 utc 표준 문자열로 업로드해주세요. 끝에 Z가 안붙으면 다음과 같은 에러가 발생합니다.
```json
{
  "code": "INVALID_INPUT_FORMAT",
  "message": "입력값 형식이 올바르지 않습니다.",
  "fieldErrors": [
    {
      "field": "recordedAt",
      "reason": "'2026-04-30T02:43:52.138' 값의 형식이 올바르지 않습니다."
    }
  ]
}
```

### 서버에서 응답해주는 시간 필드들을 모두 KST로 변환
기존엔 프론트에서 업로드해주는 시간을 그대로 반환했었고, 따로 시간대에 대한 구분을 하지 않았음
현재 응답으로 내려가는 시간 필드들은 모두 kst이며 `2026-04-29T13:32:43.059+09:00` 와 같이 끝에 offset이 붙은 kst 표준 문자열 형식으로 반환됩니다.

KST로 변경이 반영된 API는 다음과 같습니다.
- 나의 자나온길 조회 api의 recordedAt
- 방문 장소 목록 조회 api의 startTime, endTime
- 방문 장소 수정 api의 startTime, endTime
- 수기 장소 등록 api의 startTime, endTime

### 집 주소 2개 이상 등록 방지 규칙 추가
- 즐찾 장소 등록 api
  -  이미 type이 HOME인 즐찾 장소가 존재하는데, HOME type 즐찾 장소를 등록하려는 경우 예외가 발생합니다.
- 즐찾 장소 수정 api
  - 기존 type을 HOME으로 변경 요청함으로써 집주소가 2개 이상 되는 상황에 수정을 막고 예외를 발생합니다.
   
### 추가 전달사항
집주소 등록에 대한 권한 분리를 안하기로 해서 집주소 등록은 기존에 있던 즐찾 장소 등록 api쓰면 됩니다.

## 📚 추가 리팩토링 가능성
createdAt, updatedAt 필드도 Instant 타입으로 통일할까 생각중
