### PR TITLE
Feat: 주간요약 & 지표별 상세 통계 api

### DIFF
--- a/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentStatisticMetricController.java
+++ b/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentStatisticMetricController.java
@@ -1,0 +1,82 @@
+package backend.capstone.domain.care.caredependent.controller;
+
+import backend.capstone.auth.dto.UserPrincipal;
+import backend.capstone.domain.care.caredependent.service.CareDependentUserService;
+import backend.capstone.domain.mobility.statics.dto.StatisticMetricResponse;
+import backend.capstone.domain.mobility.statics.dto.VisitStatisticsResponse;
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/care/dependents/{dependentUserId}/statics/metrics")
+public class CareDependentStatisticMetricController
+    implements CareDependentStatisticMetricControllerSpec {
+
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    private final CareDependentUserService careDependentUserService;
+
+    @Override
+    @GetMapping("/outing-time")
+    public StatisticMetricResponse getDependentUserOutingTimeMetric(
+        @PathVariable("dependentUserId") Long dependentUserId,
+        @RequestParam(value = "period", defaultValue = "WEEK") StatisticPeriod period,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return careDependentUserService.getDependentUserOutingTimeMetric(
+            principal.userId(), dependentUserId, period, LocalDate.now(KST_ZONE_ID));
+    }
+
+    @Override
+    @GetMapping("/enter-home-time")
+    public StatisticMetricResponse getDependentUserEnterHomeTimeMetric(
+        @PathVariable("dependentUserId") Long dependentUserId,
+        @RequestParam(value = "period", defaultValue = "WEEK") StatisticPeriod period,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return careDependentUserService.getDependentUserEnterHomeTimeMetric(
+            principal.userId(), dependentUserId, period, LocalDate.now(KST_ZONE_ID));
+    }
+
+    @Override
+    @GetMapping("/total-outing-seconds")
+    public StatisticMetricResponse getDependentUserTotalOutingSecondsMetric(
+        @PathVariable("dependentUserId") Long dependentUserId,
+        @RequestParam(value = "period", defaultValue = "WEEK") StatisticPeriod period,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return careDependentUserService.getDependentUserTotalOutingSecondsMetric(
+            principal.userId(), dependentUserId, period, LocalDate.now(KST_ZONE_ID));
+    }
+
+    @Override
+    @GetMapping("/total-outing-count")
+    public StatisticMetricResponse getDependentUserTotalOutingCountMetric(
+        @PathVariable("dependentUserId") Long dependentUserId,
+        @RequestParam(value = "period", defaultValue = "WEEK") StatisticPeriod period,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return careDependentUserService.getDependentUserTotalOutingCountMetric(
+            principal.userId(), dependentUserId, period, LocalDate.now(KST_ZONE_ID));
+    }
+
+    @Override
+    @GetMapping("/visits")
+    public VisitStatisticsResponse getDependentUserVisitStatistics(
+        @PathVariable("dependentUserId") Long dependentUserId,
+        @RequestParam(value = "period", defaultValue = "WEEK") StatisticPeriod period,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return careDependentUserService.getDependentUserVisitStatistics(
+            principal.userId(), dependentUserId, period, LocalDate.now(KST_ZONE_ID));
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentStatisticMetricControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentStatisticMetricControllerSpec.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "함께 가는 길 API")
+@Tag(name = "보호대상자 지표별 상세 통계 API")
 public interface CareDependentStatisticMetricControllerSpec {
 
     @Operation(

--- a/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentStatisticMetricControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentStatisticMetricControllerSpec.java
@@ -1,0 +1,83 @@
+package backend.capstone.domain.care.caredependent.controller;
+
+import backend.capstone.auth.dto.UserPrincipal;
+import backend.capstone.domain.mobility.statics.dto.StatisticMetricResponse;
+import backend.capstone.domain.mobility.statics.dto.VisitStatisticsResponse;
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "함께 가는 길 API")
+public interface CareDependentStatisticMetricControllerSpec {
+
+    @Operation(
+        summary = "보호대상자 외출시각 상세 통계 조회 API",
+        description = """
+            로그인한 보호자가 연결된 보호대상자의 외출시각 상세 통계를 조회합니다.<br>
+            응답 형식과 계산 방식은 사용자의 외출시각 상세 통계 조회 API와 동일합니다.<br>
+            연결되지 않은 보호대상자를 조회하면 권한 오류가 발생합니다.
+            """
+    )
+    StatisticMetricResponse getDependentUserOutingTimeMetric(
+        Long dependentUserId,
+        @Parameter(example = "WEEK") StatisticPeriod period,
+        UserPrincipal principal
+    );
+
+    @Operation(
+        summary = "보호대상자 귀가시각 상세 통계 조회 API",
+        description = """
+            로그인한 보호자가 연결된 보호대상자의 귀가시각 상세 통계를 조회합니다.<br>
+            응답 형식과 계산 방식은 사용자의 귀가시각 상세 통계 조회 API와 동일합니다.<br>
+            연결되지 않은 보호대상자를 조회하면 권한 오류가 발생합니다.
+            """
+    )
+    StatisticMetricResponse getDependentUserEnterHomeTimeMetric(
+        Long dependentUserId,
+        @Parameter(example = "WEEK") StatisticPeriod period,
+        UserPrincipal principal
+    );
+
+    @Operation(
+        summary = "보호대상자 총 외출시간 상세 통계 조회 API",
+        description = """
+            로그인한 보호자가 연결된 보호대상자의 총 외출시간 상세 통계를 조회합니다.<br>
+            응답 형식과 계산 방식은 사용자의 총 외출시간 상세 통계 조회 API와 동일합니다.<br>
+            연결되지 않은 보호대상자를 조회하면 권한 오류가 발생합니다.
+            """
+    )
+    StatisticMetricResponse getDependentUserTotalOutingSecondsMetric(
+        Long dependentUserId,
+        @Parameter(example = "WEEK") StatisticPeriod period,
+        UserPrincipal principal
+    );
+
+    @Operation(
+        summary = "보호대상자 외출횟수 상세 통계 조회 API",
+        description = """
+            로그인한 보호자가 연결된 보호대상자의 외출횟수 상세 통계를 조회합니다.<br>
+            응답 형식과 계산 방식은 사용자의 외출횟수 상세 통계 조회 API와 동일합니다.<br>
+            연결되지 않은 보호대상자를 조회하면 권한 오류가 발생합니다.
+            """
+    )
+    StatisticMetricResponse getDependentUserTotalOutingCountMetric(
+        Long dependentUserId,
+        @Parameter(example = "WEEK") StatisticPeriod period,
+        UserPrincipal principal
+    );
+
+    @Operation(
+        summary = "보호대상자 방문 동네 및 장소 통계 조회 API",
+        description = """
+            로그인한 보호자가 연결된 보호대상자의 방문 동네 및 장소 통계를 조회합니다.<br>
+            응답 형식과 계산 방식은 사용자의 방문 동네 및 장소 통계 조회 API와 동일합니다.<br>
+            연결되지 않은 보호대상자를 조회하면 권한 오류가 발생합니다.
+            """
+    )
+    VisitStatisticsResponse getDependentUserVisitStatistics(
+        Long dependentUserId,
+        @Parameter(example = "WEEK") StatisticPeriod period,
+        UserPrincipal principal
+    );
+}

--- a/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentWeeklyStatisticsController.java
+++ b/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentWeeklyStatisticsController.java
@@ -1,0 +1,34 @@
+package backend.capstone.domain.care.caredependent.controller;
+
+import backend.capstone.auth.dto.UserPrincipal;
+import backend.capstone.domain.care.caredependent.service.CareDependentUserService;
+import backend.capstone.domain.mobility.statics.dto.WeeklyStatisticsResponse;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/care/dependents/{dependentUserId}/statics")
+public class CareDependentWeeklyStatisticsController
+    implements CareDependentWeeklyStatisticsControllerSpec {
+
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    private final CareDependentUserService careDependentUserService;
+
+    @Override
+    @GetMapping("/weekly")
+    public WeeklyStatisticsResponse getDependentUserWeeklyStatistics(
+        @PathVariable("dependentUserId") Long dependentUserId,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return careDependentUserService.getDependentUserWeeklyStatistics(
+            principal.userId(), dependentUserId, LocalDate.now(KST_ZONE_ID));
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentWeeklyStatisticsControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentWeeklyStatisticsControllerSpec.java
@@ -1,0 +1,24 @@
+package backend.capstone.domain.care.caredependent.controller;
+
+import backend.capstone.auth.dto.UserPrincipal;
+import backend.capstone.domain.mobility.statics.dto.WeeklyStatisticsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "함께 가는 길 API")
+public interface CareDependentWeeklyStatisticsControllerSpec {
+
+    @Operation(
+        summary = "보호대상자 최근 7일 주간 요약 조회 API",
+        description = """
+            로그인한 보호자가 연결된 보호대상자의 최근 7일 주간 요약 통계를 조회합니다.<br>
+            개인 사용자의 최근 7일 주간 요약 조회 API와 응답 형식이 동일합니다.<br>
+            연결되지 않은 보호대상자를 조회하면 권한 오류가 발생합니다.<br>
+            오늘 날짜는 서버의 Asia/Seoul 기준으로 계산합니다.
+            """
+    )
+    WeeklyStatisticsResponse getDependentUserWeeklyStatistics(
+        Long dependentUserId,
+        UserPrincipal principal
+    );
+}

--- a/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentWeeklyStatisticsControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/care/caredependent/controller/CareDependentWeeklyStatisticsControllerSpec.java
@@ -5,7 +5,7 @@ import backend.capstone.domain.mobility.statics.dto.WeeklyStatisticsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "함께 가는 길 API")
+@Tag(name = "보호 대상자 주간 요약 API")
 public interface CareDependentWeeklyStatisticsControllerSpec {
 
     @Operation(

--- a/backend/src/main/java/backend/capstone/domain/care/caredependent/service/CareDependentUserService.java
+++ b/backend/src/main/java/backend/capstone/domain/care/caredependent/service/CareDependentUserService.java
@@ -15,8 +15,13 @@ import backend.capstone.domain.mobility.latestgpspoint.entity.LatestGpsPoint;
 import backend.capstone.domain.mobility.latestgpspoint.repository.LatestGpsPointRepository;
 import backend.capstone.domain.mobility.place.dto.PlaceListResponse;
 import backend.capstone.domain.mobility.place.facade.PlaceFacade;
+import backend.capstone.domain.mobility.statics.dto.StatisticMetricResponse;
+import backend.capstone.domain.mobility.statics.dto.VisitStatisticsResponse;
 import backend.capstone.domain.mobility.statics.dto.WeeklyStatisticsResponse;
+import backend.capstone.domain.mobility.statics.service.StatisticMetricService;
+import backend.capstone.domain.mobility.statics.service.VisitStatisticsService;
 import backend.capstone.domain.mobility.statics.service.WeeklyStatisticsService;
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
 import backend.capstone.domain.user.entity.User;
 import backend.capstone.global.exception.BusinessException;
 import java.time.LocalDate;
@@ -40,6 +45,8 @@ public class CareDependentUserService {
     private final DayRouteFacade dayRouteFacade;
     private final PlaceFacade placeFacade;
     private final WeeklyStatisticsService weeklyStatisticsService;
+    private final StatisticMetricService statisticMetricService;
+    private final VisitStatisticsService visitStatisticsService;
 
     public CareDependentUserListResponse getDependentUsers(Long guardianUserId) {
         List<User> dependentUsers = careRelationshipRepository.findDependentUsersByGuardianUserId(
@@ -86,6 +93,41 @@ public class CareDependentUserService {
     ) {
         validateDependentUserAccess(guardianUserId, dependentUserId);
         return weeklyStatisticsService.getWeeklyStatistics(dependentUserId, today);
+    }
+
+    public StatisticMetricResponse getDependentUserOutingTimeMetric(
+        Long guardianUserId, Long dependentUserId, StatisticPeriod period, LocalDate today
+    ) {
+        validateDependentUserAccess(guardianUserId, dependentUserId);
+        return statisticMetricService.getOutingTimeMetric(dependentUserId, period, today);
+    }
+
+    public StatisticMetricResponse getDependentUserEnterHomeTimeMetric(
+        Long guardianUserId, Long dependentUserId, StatisticPeriod period, LocalDate today
+    ) {
+        validateDependentUserAccess(guardianUserId, dependentUserId);
+        return statisticMetricService.getEnterHomeTimeMetric(dependentUserId, period, today);
+    }
+
+    public StatisticMetricResponse getDependentUserTotalOutingSecondsMetric(
+        Long guardianUserId, Long dependentUserId, StatisticPeriod period, LocalDate today
+    ) {
+        validateDependentUserAccess(guardianUserId, dependentUserId);
+        return statisticMetricService.getTotalOutingSecondsMetric(dependentUserId, period, today);
+    }
+
+    public StatisticMetricResponse getDependentUserTotalOutingCountMetric(
+        Long guardianUserId, Long dependentUserId, StatisticPeriod period, LocalDate today
+    ) {
+        validateDependentUserAccess(guardianUserId, dependentUserId);
+        return statisticMetricService.getTotalOutingCountMetric(dependentUserId, period, today);
+    }
+
+    public VisitStatisticsResponse getDependentUserVisitStatistics(
+        Long guardianUserId, Long dependentUserId, StatisticPeriod period, LocalDate today
+    ) {
+        validateDependentUserAccess(guardianUserId, dependentUserId);
+        return visitStatisticsService.getVisitStatistics(dependentUserId, period, today);
     }
 
     public CareDependentDayRouteListResponse getDependentUserDayRoutes(

--- a/backend/src/main/java/backend/capstone/domain/care/caredependent/service/CareDependentUserService.java
+++ b/backend/src/main/java/backend/capstone/domain/care/caredependent/service/CareDependentUserService.java
@@ -15,6 +15,8 @@ import backend.capstone.domain.mobility.latestgpspoint.entity.LatestGpsPoint;
 import backend.capstone.domain.mobility.latestgpspoint.repository.LatestGpsPointRepository;
 import backend.capstone.domain.mobility.place.dto.PlaceListResponse;
 import backend.capstone.domain.mobility.place.facade.PlaceFacade;
+import backend.capstone.domain.mobility.statics.dto.WeeklyStatisticsResponse;
+import backend.capstone.domain.mobility.statics.service.WeeklyStatisticsService;
 import backend.capstone.domain.user.entity.User;
 import backend.capstone.global.exception.BusinessException;
 import java.time.LocalDate;
@@ -37,6 +39,7 @@ public class CareDependentUserService {
 
     private final DayRouteFacade dayRouteFacade;
     private final PlaceFacade placeFacade;
+    private final WeeklyStatisticsService weeklyStatisticsService;
 
     public CareDependentUserListResponse getDependentUsers(Long guardianUserId) {
         List<User> dependentUsers = careRelationshipRepository.findDependentUsersByGuardianUserId(
@@ -76,6 +79,13 @@ public class CareDependentUserService {
     ) {
         validateDependentUserAccess(guardianUserId, dependentUserId);
         return dayRouteFacade.getDayRouteSummary(date, dependentUserId);
+    }
+
+    public WeeklyStatisticsResponse getDependentUserWeeklyStatistics(
+        Long guardianUserId, Long dependentUserId, LocalDate today
+    ) {
+        validateDependentUserAccess(guardianUserId, dependentUserId);
+        return weeklyStatisticsService.getWeeklyStatistics(dependentUserId, today);
     }
 
     public CareDependentDayRouteListResponse getDependentUserDayRoutes(

--- a/backend/src/main/java/backend/capstone/domain/mobility/analysis/visitedregion/repository/VisitedRegionRepository.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/analysis/visitedregion/repository/VisitedRegionRepository.java
@@ -3,6 +3,7 @@ package backend.capstone.domain.mobility.analysis.visitedregion.repository;
 import backend.capstone.domain.mobility.analysis.visitedregion.entity.VisitedRegion;
 import backend.capstone.domain.mobility.dayroute.entity.DayRoute;
 import backend.capstone.domain.region.entity.Region;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -32,6 +33,20 @@ public interface VisitedRegionRepository extends JpaRepository<VisitedRegion, Lo
         """)
     List<VisitedRegion> findByDayRouteInOrderByTotalStaySecondsDesc(
         @Param("dayRoutes") List<DayRoute> dayRoutes);
+
+    @Query("""
+        select vr
+        from VisitedRegion vr
+        join fetch vr.region r
+        join vr.dayRoute dr
+        where dr.user.id = :userId
+          and dr.date between :startDate and :endDate
+        """)
+    List<VisitedRegion> findByUserIdAndDateBetween(
+        @Param("userId") Long userId,
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate
+    );
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/backend/src/main/java/backend/capstone/domain/mobility/place/repository/PlaceRepository.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/place/repository/PlaceRepository.java
@@ -2,6 +2,7 @@ package backend.capstone.domain.mobility.place.repository;
 
 import backend.capstone.domain.mobility.dayroute.entity.DayRoute;
 import backend.capstone.domain.mobility.place.entity.Place;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,6 +22,19 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     List<Place> findByDayRouteOrderByOrderIndex(DayRoute dayRoute);
 
     boolean existsByDayRoute(DayRoute dayRoute);
+
+    @Query("""
+        select p
+        from Place p
+        join p.dayRoute dr
+        where dr.user.id = :userId
+          and dr.date between :startDate and :endDate
+        """)
+    List<Place> findByUserIdAndDateBetween(
+        @Param("userId") Long userId,
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate
+    );
 
     Optional<Place> findByIdAndDayRoute(Long placeId, DayRoute dayRoute);
 

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricController.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricController.java
@@ -1,0 +1,34 @@
+package backend.capstone.domain.mobility.statics.controller;
+
+import backend.capstone.auth.dto.UserPrincipal;
+import backend.capstone.domain.mobility.statics.dto.StatisticMetricResponse;
+import backend.capstone.domain.mobility.statics.service.StatisticMetricService;
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/statics/metrics")
+public class StatisticMetricController implements StatisticMetricControllerSpec {
+
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    private final StatisticMetricService statisticMetricService;
+
+    @Override
+    @GetMapping("/outing-time")
+    public StatisticMetricResponse getOutingTimeMetric(
+        @RequestParam(value = "period", defaultValue = "WEEK") StatisticPeriod period,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return statisticMetricService.getOutingTimeMetric(
+            principal.userId(), period, LocalDate.now(KST_ZONE_ID));
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricController.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricController.java
@@ -41,4 +41,14 @@ public class StatisticMetricController implements StatisticMetricControllerSpec 
         return statisticMetricService.getEnterHomeTimeMetric(
             principal.userId(), period, LocalDate.now(KST_ZONE_ID));
     }
+
+    @Override
+    @GetMapping("/total-outing-seconds")
+    public StatisticMetricResponse getTotalOutingSecondsMetric(
+        @RequestParam(value = "period", defaultValue = "WEEK") StatisticPeriod period,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return statisticMetricService.getTotalOutingSecondsMetric(
+            principal.userId(), period, LocalDate.now(KST_ZONE_ID));
+    }
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricController.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricController.java
@@ -2,7 +2,9 @@ package backend.capstone.domain.mobility.statics.controller;
 
 import backend.capstone.auth.dto.UserPrincipal;
 import backend.capstone.domain.mobility.statics.dto.StatisticMetricResponse;
+import backend.capstone.domain.mobility.statics.dto.VisitStatisticsResponse;
 import backend.capstone.domain.mobility.statics.service.StatisticMetricService;
+import backend.capstone.domain.mobility.statics.service.VisitStatisticsService;
 import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -21,6 +23,7 @@ public class StatisticMetricController implements StatisticMetricControllerSpec 
     private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final StatisticMetricService statisticMetricService;
+    private final VisitStatisticsService visitStatisticsService;
 
     @Override
     @GetMapping("/outing-time")
@@ -59,6 +62,16 @@ public class StatisticMetricController implements StatisticMetricControllerSpec 
         @AuthenticationPrincipal UserPrincipal principal
     ) {
         return statisticMetricService.getTotalOutingCountMetric(
+            principal.userId(), period, LocalDate.now(KST_ZONE_ID));
+    }
+
+    @Override
+    @GetMapping("/visits")
+    public VisitStatisticsResponse getVisitStatistics(
+        @RequestParam(value = "period", defaultValue = "WEEK") StatisticPeriod period,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return visitStatisticsService.getVisitStatistics(
             principal.userId(), period, LocalDate.now(KST_ZONE_ID));
     }
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricController.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricController.java
@@ -31,4 +31,14 @@ public class StatisticMetricController implements StatisticMetricControllerSpec 
         return statisticMetricService.getOutingTimeMetric(
             principal.userId(), period, LocalDate.now(KST_ZONE_ID));
     }
+
+    @Override
+    @GetMapping("/enter-home-time")
+    public StatisticMetricResponse getEnterHomeTimeMetric(
+        @RequestParam(value = "period", defaultValue = "WEEK") StatisticPeriod period,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return statisticMetricService.getEnterHomeTimeMetric(
+            principal.userId(), period, LocalDate.now(KST_ZONE_ID));
+    }
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricController.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricController.java
@@ -51,4 +51,14 @@ public class StatisticMetricController implements StatisticMetricControllerSpec 
         return statisticMetricService.getTotalOutingSecondsMetric(
             principal.userId(), period, LocalDate.now(KST_ZONE_ID));
     }
+
+    @Override
+    @GetMapping("/total-outing-count")
+    public StatisticMetricResponse getTotalOutingCountMetric(
+        @RequestParam(value = "period", defaultValue = "WEEK") StatisticPeriod period,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return statisticMetricService.getTotalOutingCountMetric(
+            principal.userId(), period, LocalDate.now(KST_ZONE_ID));
+    }
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "지표 상세 통계 API")
+@Tag(name = "지표별 상세 통계 API")
 public interface StatisticMetricControllerSpec {
 
     @Operation(

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
@@ -71,4 +71,22 @@ public interface StatisticMetricControllerSpec {
         @Parameter(example = "WEEK") StatisticPeriod period,
         UserPrincipal principal
     );
+
+    @Operation(
+        summary = "총 외출시간 상세 통계 조회 API",
+        description = """
+            총 외출시간 지표를 기간별 막대 그래프 데이터로 반환합니다.<br>
+            기간별 막대 개수와 하이라이트 비교 범위는 외출시각 상세 통계와 동일합니다.<br>
+            평균은 dayRoute가 생성된 날짜의 totalOutingSeconds를 대상으로 계산합니다.<br>
+            totalOutingSeconds가 0이어도 dayRoute가 있으면 평균 계산에 포함됩니다.<br>
+            value는 평균 총 외출시간을 초 단위로 환산한 값입니다. 예: 12600 = 3시간 30분<br>
+            displayText는 value를 "n시간 n분" 형식으로 변환한 값입니다.<br>
+            조회 기간 또는 특정 막대 구간에 dayRoute가 없으면 value와 displayText는 null이고 sampleSize는 0입니다.<br>
+            하이라이트 문구는 현재 기간과 직전 기간의 평균 총 외출시간을 비교해 기록 부족, 줄어듦, 늘어남, 같음 중 하나로 반환합니다.
+            """
+    )
+    StatisticMetricResponse getTotalOutingSecondsMetric(
+        @Parameter(example = "WEEK") StatisticPeriod period,
+        UserPrincipal principal
+    );
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
@@ -1,0 +1,58 @@
+package backend.capstone.domain.mobility.statics.controller;
+
+import backend.capstone.auth.dto.UserPrincipal;
+import backend.capstone.domain.mobility.statics.dto.StatisticMetricResponse;
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "지표 상세 통계 API")
+public interface StatisticMetricControllerSpec {
+
+    @Operation(
+        summary = "외출시각 상세 통계 조회 API",
+        description = """
+            외출시각 지표를 기간별 막대 그래프 데이터로 반환합니다.<br>
+            <br>
+            <b>기간별 막대 개수</b><br>
+            - WEEK: 오늘 포함 최근 7일을 일별 7개 막대로 반환합니다.<br>
+            - MONTH: 오늘 포함 최근 30일을 일별 30개 막대로 반환합니다.<br>
+            - SIX_MONTHS: 현재 월 포함 최근 6개월을 월별 6개 막대로 반환합니다.<br>
+            - YEAR: 현재 월 포함 최근 12개월을 월별 12개 막대로 반환합니다.<br>
+            <br>
+            
+            <b>value/displayText 의미</b><br>
+            - value는 평균 외출시각을 KST 00:00부터 지난 분으로 환산한 값입니다. 예: 09:12 = 552<br>
+            - displayText는 value를 HH:mm 형식으로 변환한 값입니다.<br>
+            - 평균은 outingTime이 기록된 dayRoute만 대상으로 계산합니다. outingTime이 null인 dayRoute는 제외됩니다.<br>
+            - 평균 계산 결과는 반올림된 정수 분 단위입니다.<br>
+            - sampleSize는 평균 계산에 실제 사용된 outingTime 기록 개수입니다.<br>
+            <br>
+            
+            <b>null 응답 조건</b><br>
+            - 조회 기간 전체에 평균 계산 가능한 outingTime이 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
+            - 특정 막대 구간에 평균 계산 가능한 outingTime이 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
+            - highlight 객체는 모든 period에서 응답합니다.<br>
+            - 다만 highlight.current 또는 highlight.previous에 평균 계산 가능한 outingTime이 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
+            <br>
+            
+            <b>하이라이트 비교 범위</b><br>
+            - WEEK: 이번 주(최근 7일)와 지난주(직전 7일)를 비교합니다.<br>
+            - MONTH: 이번 달(최근 30일)과 지난달(직전 30일)을 비교합니다.<br>
+            - SIX_MONTHS: 최근 6개월과 이전 6개월을 비교합니다.<br>
+            - YEAR: 최근 1년과 이전 1년을 비교합니다.<br>
+            <br>
+            
+            <b>하이라이트 문구 규칙</b><br>
+            - 현재 기간 또는 직전 기간 중 하나라도 평균 계산 가능한 outingTime이 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
+            - 현재 기간 평균 value가 직전 기간 평균 value보다 작으면 더 이른 시간대이므로 "빨라졌어요." 문구를 반환합니다.<br>
+            - 현재 기간 평균 value가 직전 기간 평균 value보다 크면 더 늦은 시간대이므로 "늦어졌어요." 문구를 반환합니다.<br>
+            - 두 평균 value가 같으면 "같아요." 문구를 반환합니다.
+            """
+    )
+    StatisticMetricResponse getOutingTimeMetric(
+        @Parameter(example = "WEEK") StatisticPeriod period,
+        UserPrincipal principal
+    );
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
@@ -15,6 +15,7 @@ public interface StatisticMetricControllerSpec {
         summary = "외출시각 상세 통계 조회 API",
         description = """
             외출시각 지표를 기간별 막대 그래프 데이터로 반환합니다.<br>
+            period 쿼리 파라미터에 WEEK/MONTH/SIX_MONTHS/YEAR 중 한 개를 넘겨주세요. 쿼리 파라미터에 아무 값도 넘겨주지 않았을 때 디폴트는 WEEK입니다.<br> 
             <br>
             <b>기간별 막대 개수</b><br>
             - WEEK: 오늘 포함 최근 7일을 일별 7개 막대로 반환합니다.<br>
@@ -22,7 +23,7 @@ public interface StatisticMetricControllerSpec {
             - SIX_MONTHS: 현재 월 포함 최근 6개월을 월별 6개 막대로 반환합니다.<br>
             - YEAR: 현재 월 포함 최근 12개월을 월별 12개 막대로 반환합니다.<br>
             <br>
-            
+                        
             <b>value/displayText 의미</b><br>
             - value는 평균 외출시각을 KST 00:00부터 지난 분으로 환산한 값입니다. 예: 09:12 = 552<br>
             - displayText는 value를 HH:mm 형식으로 변환한 값입니다.<br>
@@ -30,21 +31,21 @@ public interface StatisticMetricControllerSpec {
             - 평균 계산 결과는 반올림된 정수 분 단위입니다.<br>
             - sampleSize는 평균 계산에 실제 사용된 outingTime 기록 개수입니다.<br>
             <br>
-            
+                        
             <b>null 응답 조건</b><br>
             - 조회 기간 전체에 평균 계산 가능한 outingTime이 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
             - 특정 막대 구간에 평균 계산 가능한 outingTime이 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
             - highlight 객체는 모든 period에서 응답합니다.<br>
             - 다만 highlight.current 또는 highlight.previous에 평균 계산 가능한 outingTime이 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
             <br>
-            
+                        
             <b>하이라이트 비교 범위</b><br>
             - WEEK: 이번 주(최근 7일)와 지난주(직전 7일)를 비교합니다.<br>
             - MONTH: 이번 달(최근 30일)과 지난달(직전 30일)을 비교합니다.<br>
             - SIX_MONTHS: 최근 6개월과 이전 6개월을 비교합니다.<br>
             - YEAR: 최근 1년과 이전 1년을 비교합니다.<br>
             <br>
-            
+                        
             <b>하이라이트 문구 규칙</b><br>
             - 현재 기간 또는 직전 기간 중 하나라도 평균 계산 가능한 outingTime이 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
             - 현재 기간 평균 value가 직전 기간 평균 value보다 작으면 더 이른 시간대이므로 "빨라졌어요." 문구를 반환합니다.<br>
@@ -61,6 +62,7 @@ public interface StatisticMetricControllerSpec {
         summary = "귀가시각 상세 통계 조회 API",
         description = """
             귀가시각 지표를 기간별 막대 그래프 데이터로 반환합니다.<br>
+            period 쿼리 파라미터에 WEEK/MONTH/SIX_MONTHS/YEAR 중 한 개를 넘겨주세요. 쿼리 파라미터에 아무 값도 넘겨주지 않았을 때 디폴트는 WEEK입니다.<br>
             <br>
             <b>기간별 막대 개수</b><br>
             - WEEK: 오늘 포함 최근 7일을 일별 7개 막대로 반환합니다.<br>
@@ -68,7 +70,7 @@ public interface StatisticMetricControllerSpec {
             - SIX_MONTHS: 현재 월 포함 최근 6개월을 월별 6개 막대로 반환합니다.<br>
             - YEAR: 현재 월 포함 최근 12개월을 월별 12개 막대로 반환합니다.<br>
             <br>
-            
+                        
             <b>value/displayText 의미</b><br>
             - value는 평균 귀가시각을 KST 00:00부터 지난 분으로 환산한 정수 값입니다. 예: 23:15 = 1395<br>
             - displayText는 value를 HH:mm 형식으로 변환한 값입니다. 예: 1395 = "23:15"<br>
@@ -76,21 +78,21 @@ public interface StatisticMetricControllerSpec {
             - 평균 계산 결과는 반올림된 정수 분 단위이며 소수점은 응답하지 않습니다.<br>
             - sampleSize는 평균 계산에 실제 사용된 enterHomeTime 기록 개수입니다.<br>
             <br>
-            
+                        
             <b>null 응답 조건</b><br>
             - 조회 기간 전체에 평균 계산 가능한 enterHomeTime이 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
             - 특정 막대 구간에 평균 계산 가능한 enterHomeTime이 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
             - highlight 객체는 모든 period에서 응답합니다.<br>
             - 다만 highlight.current 또는 highlight.previous에 평균 계산 가능한 enterHomeTime이 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
             <br>
-            
+                        
             <b>하이라이트 비교 범위</b><br>
             - WEEK: 이번 주(최근 7일)와 지난주(직전 7일)를 비교합니다.<br>
             - MONTH: 이번 달(최근 30일)과 지난달(직전 30일)을 비교합니다.<br>
             - SIX_MONTHS: 최근 6개월과 이전 6개월을 비교합니다.<br>
             - YEAR: 최근 1년과 이전 1년을 비교합니다.<br>
             <br>
-            
+                        
             <b>하이라이트 문구 규칙</b><br>
             - 현재 기간 또는 직전 기간 중 하나라도 평균 계산 가능한 enterHomeTime이 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
             - 현재 기간 평균 value가 직전 기간 평균 value보다 작으면 더 이른 시간대이므로 "빨라졌어요." 문구를 반환합니다.<br>
@@ -107,6 +109,7 @@ public interface StatisticMetricControllerSpec {
         summary = "총 외출시간 상세 통계 조회 API",
         description = """
             총 외출시간 지표를 기간별 막대 그래프 데이터로 반환합니다.<br>
+            period 쿼리 파라미터에 WEEK/MONTH/SIX_MONTHS/YEAR 중 한 개를 넘겨주세요. 쿼리 파라미터에 아무 값도 넘겨주지 않았을 때 디폴트는 WEEK입니다.<br>
             <br>
             <b>기간별 막대 개수</b><br>
             - WEEK: 오늘 포함 최근 7일을 일별 7개 막대로 반환합니다.<br>
@@ -114,7 +117,7 @@ public interface StatisticMetricControllerSpec {
             - SIX_MONTHS: 현재 월 포함 최근 6개월을 월별 6개 막대로 반환합니다.<br>
             - YEAR: 현재 월 포함 최근 12개월을 월별 12개 막대로 반환합니다.<br>
             <br>
-            
+                        
             <b>value/displayText 의미</b><br>
             평균은 dayRoute가 생성된 날짜의 totalOutingSeconds를 대상으로 계산합니다.<br>
             totalOutingSeconds가 0이어도 dayRoute가 있으면 평균 계산에 포함됩니다.<br>
@@ -125,21 +128,21 @@ public interface StatisticMetricControllerSpec {
             - displayText 예시: 0 = "0분", 1800 = "30분", 3600 = "1시간", 5400 = "1시간 30분", 10800 = "3시간"<br>
             - sampleSize는 평균 계산에 실제 사용된 dayRoute 개수입니다.<br>
             <br>
-            
+                        
             <b>null 응답 조건</b><br>
             - 조회 기간 전체에 dayRoute가 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
             - 특정 막대 구간에 dayRoute가 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
             - highlight 객체는 모든 period에서 응답합니다.<br>
             - 다만 highlight.current 또는 highlight.previous에 dayRoute가 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
             <br>
-            
+                        
             <b>하이라이트 비교 범위</b><br>
             - WEEK: 이번 주(최근 7일)와 지난주(직전 7일)를 비교합니다.<br>
             - MONTH: 이번 달(최근 30일)과 지난달(직전 30일)을 비교합니다.<br>
             - SIX_MONTHS: 최근 6개월과 이전 6개월을 비교합니다.<br>
             - YEAR: 최근 1년과 이전 1년을 비교합니다.<br>
             <br>
-            
+                        
             <b>하이라이트 문구 규칙</b><br>
             - 현재 기간 또는 직전 기간 중 하나라도 dayRoute가 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
             - 현재 기간 평균 value가 직전 기간 평균 value보다 작으면 총 외출시간이 더 짧아진 것이므로 "줄었어요." 문구를 반환합니다.<br>
@@ -156,6 +159,7 @@ public interface StatisticMetricControllerSpec {
         summary = "외출횟수 상세 통계 조회 API",
         description = """
             외출횟수 지표를 기간별 막대 그래프 데이터로 반환합니다.<br>
+            period 쿼리 파라미터에 WEEK/MONTH/SIX_MONTHS/YEAR 중 한 개를 넘겨주세요. 쿼리 파라미터에 아무 값도 넘겨주지 않았을 때 디폴트는 WEEK입니다.<br>
             <br>
             <b>기간별 막대 개수</b><br>
             - WEEK: 오늘 포함 최근 7일을 일별 7개 막대로 반환합니다.<br>
@@ -163,7 +167,7 @@ public interface StatisticMetricControllerSpec {
             - SIX_MONTHS: 현재 월 포함 최근 6개월을 월별 6개 막대로 반환합니다.<br>
             - YEAR: 현재 월 포함 최근 12개월을 월별 12개 막대로 반환합니다.<br>
             <br>
-            
+                        
             <b>value/displayText 의미</b><br>
             평균은 dayRoute가 생성된 날짜의 totalOutingCount를 대상으로 계산합니다.<br>
             totalOutingCount가 0이어도 dayRoute가 있으면 평균 계산에 포함됩니다.<br>
@@ -172,21 +176,21 @@ public interface StatisticMetricControllerSpec {
             - displayText는 value를 "n.n회" 형식으로 변환한 값입니다. 예: 0.0 = "0.0회", 1.3 = "1.3회", 2.0 = "2.0회"<br>
             - sampleSize는 평균 계산에 실제 사용된 dayRoute 개수입니다.<br>
             <br>
-            
+                        
             <b>null 응답 조건</b><br>
             - 조회 기간 전체에 dayRoute가 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
             - 특정 막대 구간에 dayRoute가 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
             - highlight 객체는 모든 period에서 응답합니다.<br>
             - 다만 highlight.current 또는 highlight.previous에 dayRoute가 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
             <br>
-            
+                        
             <b>하이라이트 비교 범위</b><br>
             - WEEK: 이번 주(최근 7일)와 지난주(직전 7일)를 비교합니다.<br>
             - MONTH: 이번 달(최근 30일)과 지난달(직전 30일)을 비교합니다.<br>
             - SIX_MONTHS: 최근 6개월과 이전 6개월을 비교합니다.<br>
             - YEAR: 최근 1년과 이전 1년을 비교합니다.<br>
             <br>
-            
+                        
             <b>하이라이트 문구 규칙</b><br>
             - 현재 기간 또는 직전 기간 중 하나라도 dayRoute가 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
             - 현재 기간 평균 value가 직전 기간 평균 value보다 작으면 평균 외출횟수가 더 적어진 것이므로 "줄었어요." 문구를 반환합니다.<br>
@@ -203,6 +207,7 @@ public interface StatisticMetricControllerSpec {
         summary = "방문 동네 및 장소 통계 조회 API",
         description = """
             사용자가 방문한 동네 분포와 가장 많이 방문한 장소 랭킹을 기간별로 반환합니다.<br>
+            period 쿼리 파라미터에 WEEK/MONTH/SIX_MONTHS/YEAR 중 한 개를 넘겨주세요. 쿼리 파라미터에 아무 값도 넘겨주지 않았을 때 디폴트는 WEEK입니다.<br>
             <br>
             <b>기간 기준</b><br>
             - WEEK: 오늘 포함 최근 7일입니다.<br>

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
@@ -89,4 +89,22 @@ public interface StatisticMetricControllerSpec {
         @Parameter(example = "WEEK") StatisticPeriod period,
         UserPrincipal principal
     );
+
+    @Operation(
+        summary = "외출횟수 상세 통계 조회 API",
+        description = """
+            외출횟수 지표를 기간별 막대 그래프 데이터로 반환합니다.<br>
+            기간별 막대 개수와 하이라이트 비교 범위는 외출시각 상세 통계와 동일합니다.<br>
+            평균은 dayRoute가 생성된 날짜의 totalOutingCount를 대상으로 계산합니다.<br>
+            totalOutingCount가 0이어도 dayRoute가 있으면 평균 계산에 포함됩니다.<br>
+            value는 평균 외출횟수를 소수점 한 자리까지 반영한 값입니다. 예: 1.3 = 1.3회<br>
+            displayText는 value를 "n.n회" 형식으로 변환한 값입니다.<br>
+            조회 기간 또는 특정 막대 구간에 dayRoute가 없으면 value와 displayText는 null이고 sampleSize는 0입니다.<br>
+            하이라이트 문구는 현재 기간과 직전 기간의 평균 외출횟수를 비교해 기록 부족, 줄어듦, 늘어남, 같음 중 하나로 반환합니다.
+            """
+    )
+    StatisticMetricResponse getTotalOutingCountMetric(
+        @Parameter(example = "WEEK") StatisticPeriod period,
+        UserPrincipal principal
+    );
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
@@ -2,6 +2,7 @@ package backend.capstone.domain.mobility.statics.controller;
 
 import backend.capstone.auth.dto.UserPrincipal;
 import backend.capstone.domain.mobility.statics.dto.StatisticMetricResponse;
+import backend.capstone.domain.mobility.statics.dto.VisitStatisticsResponse;
 import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -194,6 +195,39 @@ public interface StatisticMetricControllerSpec {
             """
     )
     StatisticMetricResponse getTotalOutingCountMetric(
+        @Parameter(example = "WEEK") StatisticPeriod period,
+        UserPrincipal principal
+    );
+
+    @Operation(
+        summary = "방문 동네 및 장소 통계 조회 API",
+        description = """
+            사용자가 방문한 동네 분포와 가장 많이 방문한 장소 랭킹을 기간별로 반환합니다.<br>
+            <br>
+            <b>기간 기준</b><br>
+            - WEEK: 오늘 포함 최근 7일입니다.<br>
+            - MONTH: 오늘 포함 최근 30일입니다.<br>
+            - SIX_MONTHS: 현재 월 포함 최근 6개월입니다.<br>
+            - YEAR: 현재 월 포함 최근 12개월입니다.<br>
+            <br>
+            <b>방문 동네 통계</b><br>
+            - visitedRegions.totalVisitCount는 기간 내 방문 동네 집계에 포함된 전체 방문 수입니다.<br>
+            - visitedRegions.items는 상위 3개 동네와 그 외 항목을 반환합니다.<br>
+            - 같은 날짜의 같은 동네는 visitedRegion 1건으로 계산합니다.<br>
+            - ratio는 전체 방문 수 대비 비율이며 소수점 한 자리까지 반환합니다.<br>
+            - displayRatio는 ratio를 반올림한 정수 퍼센트 문자열입니다. 예: "43%"<br>
+            - 방문 동네 기록이 없으면 totalVisitCount는 0, items는 빈 배열입니다.<br>
+            <br>
+            <b>방문 장소 통계</b><br>
+            - places.totalVisitCount는 기간 내 장소 방문 전체 횟수입니다.<br>
+            - places.items는 방문 횟수가 많은 장소를 최대 5개까지 반환합니다.<br>
+            - 현재는 placeName + roadAddress가 같으면 같은 장소로 집계합니다.<br>
+            - visitCount는 해당 장소 방문 횟수입니다.<br>
+            - displayVisitCount는 visitCount를 "n회" 형식으로 변환한 문자열입니다. 예: "8회"<br>
+            - 방문 장소 기록이 없으면 totalVisitCount는 0, items는 빈 배열입니다.
+            """
+    )
+    VisitStatisticsResponse getVisitStatistics(
         @Parameter(example = "WEEK") StatisticPeriod period,
         UserPrincipal principal
     );

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
@@ -60,11 +60,41 @@ public interface StatisticMetricControllerSpec {
         summary = "귀가시각 상세 통계 조회 API",
         description = """
             귀가시각 지표를 기간별 막대 그래프 데이터로 반환합니다.<br>
-            기간별 막대 개수, 평균 계산 방식, null 응답 조건, 하이라이트 비교 범위는 외출시각 상세 통계와 동일합니다.<br>
-            평균은 enterHomeTime이 기록된 dayRoute만 대상으로 계산합니다. enterHomeTime이 null인 dayRoute는 제외됩니다.<br>
-            value는 평균 귀가시각을 KST 00:00부터 지난 분으로 환산한 값입니다. 예: 23:15 = 1395<br>
-            displayText는 value를 HH:mm 형식으로 변환한 값입니다.<br>
-            하이라이트 문구는 현재 기간과 직전 기간의 평균 귀가시각을 비교해 기록 부족, 빨라짐, 늦어짐, 같음 중 하나로 반환합니다.
+            <br>
+            <b>기간별 막대 개수</b><br>
+            - WEEK: 오늘 포함 최근 7일을 일별 7개 막대로 반환합니다.<br>
+            - MONTH: 오늘 포함 최근 30일을 일별 30개 막대로 반환합니다.<br>
+            - SIX_MONTHS: 현재 월 포함 최근 6개월을 월별 6개 막대로 반환합니다.<br>
+            - YEAR: 현재 월 포함 최근 12개월을 월별 12개 막대로 반환합니다.<br>
+            <br>
+            
+            <b>value/displayText 의미</b><br>
+            - value는 평균 귀가시각을 KST 00:00부터 지난 분으로 환산한 정수 값입니다. 예: 23:15 = 1395<br>
+            - displayText는 value를 HH:mm 형식으로 변환한 값입니다. 예: 1395 = "23:15"<br>
+            - 평균은 enterHomeTime이 기록된 dayRoute만 대상으로 계산합니다. enterHomeTime이 null인 dayRoute는 제외됩니다.<br>
+            - 평균 계산 결과는 반올림된 정수 분 단위이며 소수점은 응답하지 않습니다.<br>
+            - sampleSize는 평균 계산에 실제 사용된 enterHomeTime 기록 개수입니다.<br>
+            <br>
+            
+            <b>null 응답 조건</b><br>
+            - 조회 기간 전체에 평균 계산 가능한 enterHomeTime이 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
+            - 특정 막대 구간에 평균 계산 가능한 enterHomeTime이 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
+            - highlight 객체는 모든 period에서 응답합니다.<br>
+            - 다만 highlight.current 또는 highlight.previous에 평균 계산 가능한 enterHomeTime이 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
+            <br>
+            
+            <b>하이라이트 비교 범위</b><br>
+            - WEEK: 이번 주(최근 7일)와 지난주(직전 7일)를 비교합니다.<br>
+            - MONTH: 이번 달(최근 30일)과 지난달(직전 30일)을 비교합니다.<br>
+            - SIX_MONTHS: 최근 6개월과 이전 6개월을 비교합니다.<br>
+            - YEAR: 최근 1년과 이전 1년을 비교합니다.<br>
+            <br>
+            
+            <b>하이라이트 문구 규칙</b><br>
+            - 현재 기간 또는 직전 기간 중 하나라도 평균 계산 가능한 enterHomeTime이 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
+            - 현재 기간 평균 value가 직전 기간 평균 value보다 작으면 더 이른 시간대이므로 "빨라졌어요." 문구를 반환합니다.<br>
+            - 현재 기간 평균 value가 직전 기간 평균 value보다 크면 더 늦은 시간대이므로 "늦어졌어요." 문구를 반환합니다.<br>
+            - 두 평균 value가 같으면 "같아요." 문구를 반환합니다.
             """
     )
     StatisticMetricResponse getEnterHomeTimeMetric(
@@ -76,13 +106,44 @@ public interface StatisticMetricControllerSpec {
         summary = "총 외출시간 상세 통계 조회 API",
         description = """
             총 외출시간 지표를 기간별 막대 그래프 데이터로 반환합니다.<br>
-            기간별 막대 개수와 하이라이트 비교 범위는 외출시각 상세 통계와 동일합니다.<br>
+            <br>
+            <b>기간별 막대 개수</b><br>
+            - WEEK: 오늘 포함 최근 7일을 일별 7개 막대로 반환합니다.<br>
+            - MONTH: 오늘 포함 최근 30일을 일별 30개 막대로 반환합니다.<br>
+            - SIX_MONTHS: 현재 월 포함 최근 6개월을 월별 6개 막대로 반환합니다.<br>
+            - YEAR: 현재 월 포함 최근 12개월을 월별 12개 막대로 반환합니다.<br>
+            <br>
+            
+            <b>value/displayText 의미</b><br>
             평균은 dayRoute가 생성된 날짜의 totalOutingSeconds를 대상으로 계산합니다.<br>
             totalOutingSeconds가 0이어도 dayRoute가 있으면 평균 계산에 포함됩니다.<br>
-            value는 평균 총 외출시간을 초 단위로 환산한 값입니다. 예: 12600 = 3시간 30분<br>
-            displayText는 value를 "n시간 n분" 형식으로 변환한 값입니다.<br>
-            조회 기간 또는 특정 막대 구간에 dayRoute가 없으면 value와 displayText는 null이고 sampleSize는 0입니다.<br>
-            하이라이트 문구는 현재 기간과 직전 기간의 평균 총 외출시간을 비교해 기록 부족, 줄어듦, 늘어남, 같음 중 하나로 반환합니다.
+            - value는 평균 총 외출시간을 초 단위로 환산한 정수 값입니다. 예: 12600 = 3시간 30분<br>
+            - 평균 계산 결과는 반올림된 정수 초 단위이며 소수점은 응답하지 않습니다.<br>
+            - displayText는 value를 "n시간 n분" 형식으로 변환한 값입니다.<br>
+            - displayText는 초 단위를 표시하지 않고 분 단위로 내림 처리합니다. 예: 59초 = "0분", 60초 = "1분", 3599초 = "59분"<br>
+            - displayText 예시: 0 = "0분", 1800 = "30분", 3600 = "1시간", 5400 = "1시간 30분", 10800 = "3시간"<br>
+            - sampleSize는 평균 계산에 실제 사용된 dayRoute 개수입니다.<br>
+            <br>
+            
+            <b>null 응답 조건</b><br>
+            - 조회 기간 전체에 dayRoute가 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
+            - 특정 막대 구간에 dayRoute가 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
+            - highlight 객체는 모든 period에서 응답합니다.<br>
+            - 다만 highlight.current 또는 highlight.previous에 dayRoute가 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
+            <br>
+            
+            <b>하이라이트 비교 범위</b><br>
+            - WEEK: 이번 주(최근 7일)와 지난주(직전 7일)를 비교합니다.<br>
+            - MONTH: 이번 달(최근 30일)과 지난달(직전 30일)을 비교합니다.<br>
+            - SIX_MONTHS: 최근 6개월과 이전 6개월을 비교합니다.<br>
+            - YEAR: 최근 1년과 이전 1년을 비교합니다.<br>
+            <br>
+            
+            <b>하이라이트 문구 규칙</b><br>
+            - 현재 기간 또는 직전 기간 중 하나라도 dayRoute가 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
+            - 현재 기간 평균 value가 직전 기간 평균 value보다 작으면 총 외출시간이 더 짧아진 것이므로 "줄었어요." 문구를 반환합니다.<br>
+            - 현재 기간 평균 value가 직전 기간 평균 value보다 크면 총 외출시간이 더 길어진 것이므로 "늘었어요." 문구를 반환합니다.<br>
+            - 두 평균 value가 같으면 "같아요." 문구를 반환합니다.
             """
     )
     StatisticMetricResponse getTotalOutingSecondsMetric(
@@ -94,13 +155,42 @@ public interface StatisticMetricControllerSpec {
         summary = "외출횟수 상세 통계 조회 API",
         description = """
             외출횟수 지표를 기간별 막대 그래프 데이터로 반환합니다.<br>
-            기간별 막대 개수와 하이라이트 비교 범위는 외출시각 상세 통계와 동일합니다.<br>
+            <br>
+            <b>기간별 막대 개수</b><br>
+            - WEEK: 오늘 포함 최근 7일을 일별 7개 막대로 반환합니다.<br>
+            - MONTH: 오늘 포함 최근 30일을 일별 30개 막대로 반환합니다.<br>
+            - SIX_MONTHS: 현재 월 포함 최근 6개월을 월별 6개 막대로 반환합니다.<br>
+            - YEAR: 현재 월 포함 최근 12개월을 월별 12개 막대로 반환합니다.<br>
+            <br>
+            
+            <b>value/displayText 의미</b><br>
             평균은 dayRoute가 생성된 날짜의 totalOutingCount를 대상으로 계산합니다.<br>
             totalOutingCount가 0이어도 dayRoute가 있으면 평균 계산에 포함됩니다.<br>
-            value는 평균 외출횟수를 소수점 한 자리까지 반영한 값입니다. 예: 1.3 = 1.3회<br>
-            displayText는 value를 "n.n회" 형식으로 변환한 값입니다.<br>
-            조회 기간 또는 특정 막대 구간에 dayRoute가 없으면 value와 displayText는 null이고 sampleSize는 0입니다.<br>
-            하이라이트 문구는 현재 기간과 직전 기간의 평균 외출횟수를 비교해 기록 부족, 줄어듦, 늘어남, 같음 중 하나로 반환합니다.
+            - value는 평균 외출횟수를 소수점 한 자리까지 반영한 값입니다. 예: 1.3<br>
+            - 평균 계산 결과는 소수점 둘째 자리에서 반올림해 소수점 한 자리까지 응답합니다.<br>
+            - displayText는 value를 "n.n회" 형식으로 변환한 값입니다. 예: 0.0 = "0.0회", 1.3 = "1.3회", 2.0 = "2.0회"<br>
+            - sampleSize는 평균 계산에 실제 사용된 dayRoute 개수입니다.<br>
+            <br>
+            
+            <b>null 응답 조건</b><br>
+            - 조회 기간 전체에 dayRoute가 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
+            - 특정 막대 구간에 dayRoute가 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
+            - highlight 객체는 모든 period에서 응답합니다.<br>
+            - 다만 highlight.current 또는 highlight.previous에 dayRoute가 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
+            <br>
+            
+            <b>하이라이트 비교 범위</b><br>
+            - WEEK: 이번 주(최근 7일)와 지난주(직전 7일)를 비교합니다.<br>
+            - MONTH: 이번 달(최근 30일)과 지난달(직전 30일)을 비교합니다.<br>
+            - SIX_MONTHS: 최근 6개월과 이전 6개월을 비교합니다.<br>
+            - YEAR: 최근 1년과 이전 1년을 비교합니다.<br>
+            <br>
+            
+            <b>하이라이트 문구 규칙</b><br>
+            - 현재 기간 또는 직전 기간 중 하나라도 dayRoute가 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
+            - 현재 기간 평균 value가 직전 기간 평균 value보다 작으면 평균 외출횟수가 더 적어진 것이므로 "줄었어요." 문구를 반환합니다.<br>
+            - 현재 기간 평균 value가 직전 기간 평균 value보다 크면 평균 외출횟수가 더 많아진 것이므로 "늘었어요." 문구를 반환합니다.<br>
+            - 두 평균 value가 같으면 "같아요." 문구를 반환합니다.
             """
     )
     StatisticMetricResponse getTotalOutingCountMetric(

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
@@ -119,21 +119,22 @@ public interface StatisticMetricControllerSpec {
             <br>
                         
             <b>value/displayText 의미</b><br>
-            평균은 dayRoute가 생성된 날짜의 totalOutingSeconds를 대상으로 계산합니다.<br>
-            totalOutingSeconds가 0이어도 dayRoute가 있으면 평균 계산에 포함됩니다.<br>
+            평균은 outingTime이 기록된 dayRoute의 totalOutingSeconds를 대상으로 계산합니다.<br>
+            outingTime이 null인 dayRoute는 외출 기록이 없는 날로 보고 평균 계산에서 제외됩니다.<br>
+            totalOutingSeconds가 0이어도 outingTime이 있으면 평균 계산에 포함됩니다.<br>
             - value는 평균 총 외출시간을 초 단위로 환산한 정수 값입니다. 예: 12600 = 3시간 30분<br>
             - 평균 계산 결과는 반올림된 정수 초 단위이며 소수점은 응답하지 않습니다.<br>
             - displayText는 value를 "n시간 n분" 형식으로 변환한 값입니다.<br>
             - displayText는 초 단위를 표시하지 않고 분 단위로 내림 처리합니다. 예: 59초 = "0분", 60초 = "1분", 3599초 = "59분"<br>
             - displayText 예시: 0 = "0분", 1800 = "30분", 3600 = "1시간", 5400 = "1시간 30분", 10800 = "3시간"<br>
-            - sampleSize는 평균 계산에 실제 사용된 dayRoute 개수입니다.<br>
+            - sampleSize는 평균 계산에 실제 사용된 외출 기록 개수입니다.<br>
             <br>
                         
             <b>null 응답 조건</b><br>
-            - 조회 기간 전체에 dayRoute가 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
-            - 특정 막대 구간에 dayRoute가 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
+            - 조회 기간 전체에 평균 계산 가능한 외출 기록이 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
+            - 특정 막대 구간에 평균 계산 가능한 외출 기록이 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
             - highlight 객체는 모든 period에서 응답합니다.<br>
-            - 다만 highlight.current 또는 highlight.previous에 dayRoute가 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
+            - 다만 highlight.current 또는 highlight.previous에 평균 계산 가능한 외출 기록이 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
             <br>
                         
             <b>하이라이트 비교 범위</b><br>
@@ -144,7 +145,7 @@ public interface StatisticMetricControllerSpec {
             <br>
                         
             <b>하이라이트 문구 규칙</b><br>
-            - 현재 기간 또는 직전 기간 중 하나라도 dayRoute가 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
+            - 현재 기간 또는 직전 기간 중 하나라도 평균 계산 가능한 외출 기록이 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
             - 현재 기간 평균 value가 직전 기간 평균 value보다 작으면 총 외출시간이 더 짧아진 것이므로 "줄었어요." 문구를 반환합니다.<br>
             - 현재 기간 평균 value가 직전 기간 평균 value보다 크면 총 외출시간이 더 길어진 것이므로 "늘었어요." 문구를 반환합니다.<br>
             - 두 평균 value가 같으면 "같아요." 문구를 반환합니다.
@@ -169,19 +170,20 @@ public interface StatisticMetricControllerSpec {
             <br>
                         
             <b>value/displayText 의미</b><br>
-            평균은 dayRoute가 생성된 날짜의 totalOutingCount를 대상으로 계산합니다.<br>
-            totalOutingCount가 0이어도 dayRoute가 있으면 평균 계산에 포함됩니다.<br>
+            평균은 outingTime이 기록된 dayRoute의 totalOutingCount를 대상으로 계산합니다.<br>
+            outingTime이 null인 dayRoute는 외출 기록이 없는 날로 보고 평균 계산에서 제외됩니다.<br>
+            totalOutingCount가 0이어도 outingTime이 있으면 평균 계산에 포함됩니다.<br>
             - value는 평균 외출횟수를 소수점 한 자리까지 반영한 값입니다. 예: 1.3<br>
             - 평균 계산 결과는 소수점 둘째 자리에서 반올림해 소수점 한 자리까지 응답합니다.<br>
             - displayText는 value를 "n.n회" 형식으로 변환한 값입니다. 예: 0.0 = "0.0회", 1.3 = "1.3회", 2.0 = "2.0회"<br>
-            - sampleSize는 평균 계산에 실제 사용된 dayRoute 개수입니다.<br>
+            - sampleSize는 평균 계산에 실제 사용된 외출 기록 개수입니다.<br>
             <br>
                         
             <b>null 응답 조건</b><br>
-            - 조회 기간 전체에 dayRoute가 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
-            - 특정 막대 구간에 dayRoute가 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
+            - 조회 기간 전체에 평균 계산 가능한 외출 기록이 없으면 average.value와 average.displayText는 null이고 sampleSize는 0입니다.<br>
+            - 특정 막대 구간에 평균 계산 가능한 외출 기록이 없으면 해당 bar.value와 bar.displayText는 null, hasValue는 false, sampleSize는 0입니다.<br>
             - highlight 객체는 모든 period에서 응답합니다.<br>
-            - 다만 highlight.current 또는 highlight.previous에 dayRoute가 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
+            - 다만 highlight.current 또는 highlight.previous에 평균 계산 가능한 외출 기록이 없으면 해당 value와 displayText는 null이고 sampleSize는 0입니다.<br>
             <br>
                         
             <b>하이라이트 비교 범위</b><br>
@@ -192,7 +194,7 @@ public interface StatisticMetricControllerSpec {
             <br>
                         
             <b>하이라이트 문구 규칙</b><br>
-            - 현재 기간 또는 직전 기간 중 하나라도 dayRoute가 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
+            - 현재 기간 또는 직전 기간 중 하나라도 평균 계산 가능한 외출 기록이 없으면 "비교할 기록이 부족해요." 문구를 반환합니다.<br>
             - 현재 기간 평균 value가 직전 기간 평균 value보다 작으면 평균 외출횟수가 더 적어진 것이므로 "줄었어요." 문구를 반환합니다.<br>
             - 현재 기간 평균 value가 직전 기간 평균 value보다 크면 평균 외출횟수가 더 많아진 것이므로 "늘었어요." 문구를 반환합니다.<br>
             - 두 평균 value가 같으면 "같아요." 문구를 반환합니다.

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/StatisticMetricControllerSpec.java
@@ -55,4 +55,20 @@ public interface StatisticMetricControllerSpec {
         @Parameter(example = "WEEK") StatisticPeriod period,
         UserPrincipal principal
     );
+
+    @Operation(
+        summary = "귀가시각 상세 통계 조회 API",
+        description = """
+            귀가시각 지표를 기간별 막대 그래프 데이터로 반환합니다.<br>
+            기간별 막대 개수, 평균 계산 방식, null 응답 조건, 하이라이트 비교 범위는 외출시각 상세 통계와 동일합니다.<br>
+            평균은 enterHomeTime이 기록된 dayRoute만 대상으로 계산합니다. enterHomeTime이 null인 dayRoute는 제외됩니다.<br>
+            value는 평균 귀가시각을 KST 00:00부터 지난 분으로 환산한 값입니다. 예: 23:15 = 1395<br>
+            displayText는 value를 HH:mm 형식으로 변환한 값입니다.<br>
+            하이라이트 문구는 현재 기간과 직전 기간의 평균 귀가시각을 비교해 기록 부족, 빨라짐, 늦어짐, 같음 중 하나로 반환합니다.
+            """
+    )
+    StatisticMetricResponse getEnterHomeTimeMetric(
+        @Parameter(example = "WEEK") StatisticPeriod period,
+        UserPrincipal principal
+    );
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/WeeklyStatisticsController.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/WeeklyStatisticsController.java
@@ -1,0 +1,29 @@
+package backend.capstone.domain.mobility.statics.controller;
+
+import backend.capstone.auth.dto.UserPrincipal;
+import backend.capstone.domain.mobility.statics.dto.WeeklyStatisticsResponse;
+import backend.capstone.domain.mobility.statics.service.WeeklyStatisticsService;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/statics")
+public class WeeklyStatisticsController implements WeeklyStatisticsControllerSpec {
+
+    private final WeeklyStatisticsService weeklyStatisticsService;
+
+    @Override
+    @GetMapping("/weekly")
+    public WeeklyStatisticsResponse getWeeklyStatistics(
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return weeklyStatisticsService.getWeeklyStatistics(principal.userId(),
+            LocalDate.now(ZoneId.of("Asia/Seoul")));
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/WeeklyStatisticsControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/WeeklyStatisticsControllerSpec.java
@@ -1,0 +1,29 @@
+package backend.capstone.domain.mobility.statics.controller;
+
+import backend.capstone.auth.dto.UserPrincipal;
+import backend.capstone.domain.mobility.statics.dto.WeeklyStatisticsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "주간 통계 API")
+public interface WeeklyStatisticsControllerSpec {
+
+    @Operation(
+        summary = "최근 7일 주간 통계 조회 API",
+        description = """
+            오늘 날짜를 기준으로 최근 7일간의 통계가 날짜 오름차순으로 반환합니다.<br>
+            최근 7일간 생성된 dayRoute가 없다면 평균을 계산할 수치가 없어 각 필드의 `average`의 `value`와 `displayText`는 nulll이 됩니다. (이때 nulll이 아니라 0이나 "-" 같은 문자열을 받고 싶으면 얘기 바람)
+                        
+            - `hasDayRoute`: 해당 날짜에 데이터가 존재하는지 여부<br>
+                - 만약 `hasDayRoute`가 false라면 해당 날짜에 데이터가 존재하지 않아 dayRoute 엔티티가 생성되지 않은 것입니다.<br>
+                따라서 해당 날짜의 `value`와 `displayText`도 null이 반환되며 해당 날짜는 평균 계산에 사용되지 않습니다.<br><br>
+            - `sampleSize`: 평균 계산에 사용된 기록 일수 (최근 7일 간 dayRoute가 생성된 날짜 수)<br><br>
+            - `value`: 평균을 정량적인 값으로 환산한 값으로 막대 그래프를 표시할 때 정량적으로 판단할 수 있는 값입니다.<br><br>
+              - `outingTime`과 `enterHomeTime`의 `value`는 시간을 분으로 환산한 값<br>
+                `totalOutingSeconds.value`: 해당 날짜의 총 외출 시간을 초 단위로 계산한 값<br>
+                `totalOutingCount.value`: 외출횟수를 소수점 한자리까지 계산한 값<br><br>
+            - `topRegions`: 방문한 동네가 없으면 빈배열이 반환되며 최대 2개까지 반환됩니다.
+            """
+    )
+    WeeklyStatisticsResponse getWeeklyStatistics(UserPrincipal principal);
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/WeeklyStatisticsControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/WeeklyStatisticsControllerSpec.java
@@ -12,7 +12,7 @@ public interface WeeklyStatisticsControllerSpec {
         summary = "최근 7일 주간 요약 조회 API",
         description = """
             오늘 날짜를 기준으로 최근 7일간의 통계가 날짜 오름차순으로 반환합니다.<br>
-            최근 7일간 생성된 dayRoute가 없다면 평균을 계산할 수치가 없어 각 필드의 `average`의 `value`와 `displayText`는 nulll이 됩니다. (이때 nulll이 아니라 0이나 "-" 같은 문자열을 받고 싶으면 얘기 바람)
+            최근 7일간 생성된 dayRoute가 없다면 평균을 계산할 수치가 없어 각 필드의 `average`의 `value`와 `displayText`는 nulll이 됩니다.
                         
             - `hasDayRoute`: 해당 날짜에 데이터가 존재하는지 여부<br>
                 - 만약 `hasDayRoute`가 false라면 해당 날짜에 데이터가 존재하지 않아 dayRoute 엔티티가 생성되지 않은 것입니다.<br>

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/WeeklyStatisticsControllerSpec.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/controller/WeeklyStatisticsControllerSpec.java
@@ -5,11 +5,11 @@ import backend.capstone.domain.mobility.statics.dto.WeeklyStatisticsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "주간 통계 API")
+@Tag(name = "주간 요약 API")
 public interface WeeklyStatisticsControllerSpec {
 
     @Operation(
-        summary = "최근 7일 주간 통계 조회 API",
+        summary = "최근 7일 주간 요약 조회 API",
         description = """
             오늘 날짜를 기준으로 최근 7일간의 통계가 날짜 오름차순으로 반환합니다.<br>
             최근 7일간 생성된 dayRoute가 없다면 평균을 계산할 수치가 없어 각 필드의 `average`의 `value`와 `displayText`는 nulll이 됩니다. (이때 nulll이 아니라 0이나 "-" 같은 문자열을 받고 싶으면 얘기 바람)

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/CountMetricSection.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/CountMetricSection.java
@@ -1,0 +1,40 @@
+package backend.capstone.domain.mobility.statics.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+public record CountMetricSection(
+    CountMetricAverage average,
+    List<CountMetricDailyItem> dailyValues
+) {
+
+    public record CountMetricAverage(
+        @Schema(example = "1.3", description = "평균 외출 횟수")
+        Double value,
+
+        @Schema(example = "1.3회", description = "평균 외출 횟수 표시 문자열")
+        String displayText,
+
+        @Schema(example = "7", description = "평균 계산에 사용된 기록 일수")
+        int sampleSize
+    ) {
+
+    }
+
+    public record CountMetricDailyItem(
+        @Schema(example = "2026-05-07", description = "일자")
+        LocalDate date,
+
+        @Schema(example = "true", description = "해당 날짜 dayRoute 존재 여부")
+        boolean hasDayRoute,
+
+        @Schema(example = "1", description = "해당 날짜 외출 횟수")
+        Integer value,
+
+        @Schema(example = "1회", description = "외출 횟수 표시 문자열")
+        String displayText
+    ) {
+
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/CountMetricSection.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/CountMetricSection.java
@@ -5,8 +5,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record CountMetricSection(
+    @Schema(description = "기록된 dayRoute 기준 평균 외출 횟수")
     CountMetricAverage average,
-    List<CountMetricDailyItem> dailyValues
+
+    @Schema(description = "최근 7일 일자별 외출 횟수. dayRoute가 없는 날짜도 null 값으로 포함됩니다.")
+    List<CountMetricDailyItem> sevenDays
 ) {
 
     public record CountMetricAverage(

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/DurationMetricSection.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/DurationMetricSection.java
@@ -5,13 +5,16 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record DurationMetricSection(
+    @Schema(description = "기록된 dayRoute 기준 평균 외출 시간")
     DurationMetricAverage average,
-    List<DurationMetricDailyItem> dailyValues
+
+    @Schema(description = "최근 7일 일자별 총 외출 시간. dayRoute가 없는 날짜도 null 값으로 포함됩니다.")
+    List<DurationMetricDailyItem> sevenDays
 ) {
 
     public record DurationMetricAverage(
-        @Schema(example = "19800", description = "평균 외출 시간(초)")
-        Long value,
+        @Schema(example = "19800.5", description = "평균 외출 시간(초), 소수점 한 자리까지 반환")
+        Double value,
 
         @Schema(example = "5시간 30분", description = "평균 외출 시간 표시 문자열")
         String displayText,
@@ -29,7 +32,7 @@ public record DurationMetricSection(
         @Schema(example = "true", description = "해당 날짜 dayRoute 존재 여부")
         boolean hasDayRoute,
 
-        @Schema(example = "19800", description = "해당 날짜 외출 시간(초)")
+        @Schema(example = "19800", description = "해당 날짜 총 외출 시간(초)")
         Long value,
 
         @Schema(example = "5시간 30분", description = "외출 시간 표시 문자열")

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/DurationMetricSection.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/DurationMetricSection.java
@@ -1,0 +1,40 @@
+package backend.capstone.domain.mobility.statics.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+public record DurationMetricSection(
+    DurationMetricAverage average,
+    List<DurationMetricDailyItem> dailyValues
+) {
+
+    public record DurationMetricAverage(
+        @Schema(example = "19800", description = "평균 외출 시간(초)")
+        Long value,
+
+        @Schema(example = "5시간 30분", description = "평균 외출 시간 표시 문자열")
+        String displayText,
+
+        @Schema(example = "7", description = "평균 계산에 사용된 기록 일수")
+        int sampleSize
+    ) {
+
+    }
+
+    public record DurationMetricDailyItem(
+        @Schema(example = "2026-05-07", description = "일자")
+        LocalDate date,
+
+        @Schema(example = "true", description = "해당 날짜 dayRoute 존재 여부")
+        boolean hasDayRoute,
+
+        @Schema(example = "19800", description = "해당 날짜 외출 시간(초)")
+        Long value,
+
+        @Schema(example = "5시간 30분", description = "외출 시간 표시 문자열")
+        String displayText
+    ) {
+
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/PlaceStatisticsSection.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/PlaceStatisticsSection.java
@@ -1,0 +1,31 @@
+package backend.capstone.domain.mobility.statics.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record PlaceStatisticsSection(
+    @Schema(example = "32", description = "장소 통계에 포함된 전체 방문 수")
+    int totalVisitCount,
+
+    @Schema(description = "가장 많이 방문한 장소 목록. 최대 5개를 반환합니다.")
+    List<PlaceStatisticsItem> items
+) {
+
+    public record PlaceStatisticsItem(
+        @Schema(example = "1", description = "순위")
+        int rank,
+
+        @Schema(example = "스타벅스 수유역점", description = "장소 이름")
+        String placeName,
+
+        @Schema(example = "서울특별시 성북구 정릉로 77", description = "도로명 주소")
+        String roadAddress,
+
+        @Schema(example = "8", description = "방문 횟수")
+        int visitCount,
+
+        @Schema(example = "8회", description = "프론트 표시용 방문 횟수 문자열")
+        String displayVisitCount
+    ) {
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/StatisticMetricResponse.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/StatisticMetricResponse.java
@@ -29,8 +29,8 @@ public record StatisticMetricResponse(
 ) {
 
     public record StatisticMetricAverage(
-        @Schema(example = "552", description = "평균 외출시각을 KST 00:00부터 지난 분으로 환산한 값")
-        Integer value,
+        @Schema(example = "552", description = "지표 평균 값. 시간 지표는 분, 총 외출시간은 초, 외출횟수는 횟수 단위")
+        Number value,
 
         @Schema(example = "09:12", description = "평균 외출시각 표시 문자열")
         String displayText,
@@ -51,8 +51,8 @@ public record StatisticMetricResponse(
         @Schema(example = "2026-05-12", description = "구간 종료일")
         LocalDate endDate,
 
-        @Schema(example = "540", description = "구간 평균 외출시각을 KST 00:00부터 지난 분으로 환산한 값")
-        Integer value,
+        @Schema(example = "540", description = "구간 평균 값. 시간 지표는 분, 총 외출시간은 초, 외출횟수는 횟수 단위")
+        Number value,
 
         @Schema(example = "09:00", description = "구간 평균 외출시각 표시 문자열")
         String displayText,
@@ -86,8 +86,8 @@ public record StatisticMetricResponse(
         @Schema(example = "이번 주", description = "비교 항목 라벨")
         String label,
 
-        @Schema(example = "510", description = "평균 외출시각을 KST 00:00부터 지난 분으로 환산한 값")
-        Integer value,
+        @Schema(example = "510", description = "비교 기간 평균 값. 시간 지표는 분, 총 외출시간은 초, 외출횟수는 횟수 단위")
+        Number value,
 
         @Schema(example = "08:30", description = "평균 외출시각 표시 문자열")
         String displayText,

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/StatisticMetricResponse.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/StatisticMetricResponse.java
@@ -1,0 +1,100 @@
+package backend.capstone.domain.mobility.statics.dto;
+
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+public record StatisticMetricResponse(
+    @Schema(example = "OUTING_TIME", description = "통계 지표 타입")
+    String metricType,
+
+    @Schema(example = "WEEK", description = "조회 기간")
+    StatisticPeriod period,
+
+    @Schema(example = "2026-05-12", description = "조회 시작일")
+    LocalDate startDate,
+
+    @Schema(example = "2026-05-18", description = "조회 종료일")
+    LocalDate endDate,
+
+    @Schema(description = "조회 기간 전체 평균")
+    StatisticMetricAverage average,
+
+    @Schema(description = "막대 그래프 표시용 구간별 값")
+    List<StatisticMetricBarItem> bars,
+
+    @Schema(description = "현재 기간과 직전 기간 비교 하이라이트")
+    StatisticMetricHighlight highlight
+) {
+
+    public record StatisticMetricAverage(
+        @Schema(example = "552", description = "평균 외출시각을 KST 00:00부터 지난 분으로 환산한 값")
+        Integer value,
+
+        @Schema(example = "09:12", description = "평균 외출시각 표시 문자열")
+        String displayText,
+
+        @Schema(example = "5", description = "평균 계산에 사용된 기록 개수")
+        int sampleSize
+    ) {
+
+    }
+
+    public record StatisticMetricBarItem(
+        @Schema(example = "월", description = "프론트 막대 그래프 라벨")
+        String label,
+
+        @Schema(example = "2026-05-12", description = "구간 시작일")
+        LocalDate startDate,
+
+        @Schema(example = "2026-05-12", description = "구간 종료일")
+        LocalDate endDate,
+
+        @Schema(example = "540", description = "구간 평균 외출시각을 KST 00:00부터 지난 분으로 환산한 값")
+        Integer value,
+
+        @Schema(example = "09:00", description = "구간 평균 외출시각 표시 문자열")
+        String displayText,
+
+        @Schema(example = "true", description = "구간에 평균 계산 가능한 값이 존재하는지 여부")
+        boolean hasValue,
+
+        @Schema(example = "1", description = "구간 평균 계산에 사용된 기록 개수")
+        int sampleSize
+    ) {
+
+    }
+
+    public record StatisticMetricHighlight(
+        @Schema(example = "이번 주 외출", description = "하이라이트 제목")
+        String title,
+
+        @Schema(example = "이번 주 평균 외출 시간이 지난주보다 빨라졌어요.", description = "하이라이트 문구")
+        String message,
+
+        @Schema(description = "현재 기간 평균")
+        HighlightMetricValue current,
+
+        @Schema(description = "직전 기간 평균")
+        HighlightMetricValue previous
+    ) {
+
+    }
+
+    public record HighlightMetricValue(
+        @Schema(example = "이번 주", description = "비교 항목 라벨")
+        String label,
+
+        @Schema(example = "510", description = "평균 외출시각을 KST 00:00부터 지난 분으로 환산한 값")
+        Integer value,
+
+        @Schema(example = "08:30", description = "평균 외출시각 표시 문자열")
+        String displayText,
+
+        @Schema(example = "5", description = "평균 계산에 사용된 기록 개수")
+        int sampleSize
+    ) {
+
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/TimeMetricSection.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/TimeMetricSection.java
@@ -5,12 +5,15 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record TimeMetricSection(
+    @Schema(description = "기록된 dayRoute 기준 평균 시각")
     TimeMetricAverage average,
-    List<TimeMetricDailyItem> dailyValues
+
+    @Schema(description = "최근 7일 일자별 시각 값. dayRoute가 없는 날짜도 null 값으로 포함됩니다.")
+    List<TimeMetricDailyItem> sevenDays
 ) {
 
     public record TimeMetricAverage(
-        @Schema(example = "552", description = "평균 시각을 분 단위로 환산한 값")
+        @Schema(example = "552", description = "평균 시각을 KST 00:00부터 지난 분으로 환산한 값")
         Integer value,
 
         @Schema(example = "09:12", description = "평균 시각 표시 문자열")
@@ -29,7 +32,7 @@ public record TimeMetricSection(
         @Schema(example = "true", description = "해당 날짜 dayRoute 존재 여부")
         boolean hasDayRoute,
 
-        @Schema(example = "540", description = "시각을 분 단위로 환산한 값")
+        @Schema(example = "540", description = "시각을 KST 00:00부터 지난 분으로 환산한 값")
         Integer value,
 
         @Schema(example = "09:00", description = "시각 표시 문자열")

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/TimeMetricSection.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/TimeMetricSection.java
@@ -1,0 +1,40 @@
+package backend.capstone.domain.mobility.statics.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+public record TimeMetricSection(
+    TimeMetricAverage average,
+    List<TimeMetricDailyItem> dailyValues
+) {
+
+    public record TimeMetricAverage(
+        @Schema(example = "552", description = "평균 시각을 분 단위로 환산한 값")
+        Integer value,
+
+        @Schema(example = "09:12", description = "평균 시각 표시 문자열")
+        String displayText,
+
+        @Schema(example = "5", description = "평균 계산에 사용된 기록 일수")
+        int sampleSize
+    ) {
+
+    }
+
+    public record TimeMetricDailyItem(
+        @Schema(example = "2026-05-07", description = "일자")
+        LocalDate date,
+
+        @Schema(example = "true", description = "해당 날짜 dayRoute 존재 여부")
+        boolean hasDayRoute,
+
+        @Schema(example = "540", description = "시각을 분 단위로 환산한 값")
+        Integer value,
+
+        @Schema(example = "09:00", description = "시각 표시 문자열")
+        String displayText
+    ) {
+
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/VisitStatisticsResponse.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/VisitStatisticsResponse.java
@@ -1,0 +1,23 @@
+package backend.capstone.domain.mobility.statics.dto;
+
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record VisitStatisticsResponse(
+    @Schema(example = "WEEK", description = "조회 기간")
+    StatisticPeriod period,
+
+    @Schema(example = "2026-05-12", description = "조회 시작일")
+    LocalDate startDate,
+
+    @Schema(example = "2026-05-18", description = "조회 종료일")
+    LocalDate endDate,
+
+    @Schema(description = "방문 동네 분포")
+    VisitedRegionStatisticsSection visitedRegions,
+
+    @Schema(description = "가장 많이 방문한 장소")
+    PlaceStatisticsSection places
+) {
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/VisitedRegionStatisticsSection.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/VisitedRegionStatisticsSection.java
@@ -1,0 +1,31 @@
+package backend.capstone.domain.mobility.statics.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record VisitedRegionStatisticsSection(
+    @Schema(example = "21", description = "방문 동네 통계에 포함된 전체 방문 수")
+    int totalVisitCount,
+
+    @Schema(description = "방문 동네 비율 목록. 상위 3개 동네와 그 외를 반환합니다.")
+    List<VisitedRegionStatisticsItem> items
+) {
+
+    public record VisitedRegionStatisticsItem(
+        @Schema(example = "1", description = "순위")
+        int rank,
+
+        @Schema(example = "수유동", description = "동네 이름. 그 외 항목은 '그 외'로 반환합니다.")
+        String regionName,
+
+        @Schema(example = "9", description = "해당 동네 방문 수")
+        int visitCount,
+
+        @Schema(example = "42.9", description = "전체 방문 수 대비 비율. 소수점 한 자리까지 반환합니다.")
+        double ratio,
+
+        @Schema(example = "43%", description = "프론트 표시용 정수 퍼센트 문자열")
+        String displayRatio
+    ) {
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/VisitedRegionsSection.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/VisitedRegionsSection.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record VisitedRegionsSection(
+    @Schema(description = "최근 7일 누적 체류 시간 기준 상위 방문 지역 목록")
     List<VisitedRegionSummaryItem> topRegions
 ) {
 
@@ -12,13 +13,7 @@ public record VisitedRegionsSection(
         int rank,
 
         @Schema(example = "성북구", description = "방문 지역 이름")
-        String regionName,
-
-        @Schema(example = "14400", description = "최근 7일 누적 체류 시간(초)")
-        long totalStaySeconds,
-
-        @Schema(example = "3", description = "방문한 날짜 수")
-        int visitDays
+        String regionName
     ) {
 
     }

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/VisitedRegionsSection.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/VisitedRegionsSection.java
@@ -1,0 +1,25 @@
+package backend.capstone.domain.mobility.statics.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record VisitedRegionsSection(
+    List<VisitedRegionSummaryItem> topRegions
+) {
+
+    public record VisitedRegionSummaryItem(
+        @Schema(example = "1", description = "순위")
+        int rank,
+
+        @Schema(example = "성북구", description = "방문 지역 이름")
+        String regionName,
+
+        @Schema(example = "14400", description = "최근 7일 누적 체류 시간(초)")
+        long totalStaySeconds,
+
+        @Schema(example = "3", description = "방문한 날짜 수")
+        int visitDays
+    ) {
+
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/WeeklyStatisticsResponse.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/WeeklyStatisticsResponse.java
@@ -1,0 +1,19 @@
+package backend.capstone.domain.mobility.statics.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record WeeklyStatisticsResponse(
+    @Schema(example = "2026-05-07", description = "최근 7일 통계 시작일")
+    LocalDate startDate,
+
+    @Schema(example = "2026-05-13", description = "최근 7일 통계 종료일")
+    LocalDate endDate,
+
+    TimeMetricSection outingTime,
+    TimeMetricSection enterHomeTime,
+    CountMetricSection totalOutingCount,
+    DurationMetricSection totalOutingSeconds,
+    VisitedRegionsSection visitedRegions
+) {
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/WeeklyStatisticsResponse.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/dto/WeeklyStatisticsResponse.java
@@ -10,10 +10,19 @@ public record WeeklyStatisticsResponse(
     @Schema(example = "2026-05-13", description = "최근 7일 통계 종료일")
     LocalDate endDate,
 
+    @Schema(description = "주간 외출 시각 통계. value는 KST 기준 00:00부터 지난 분입니다.")
     TimeMetricSection outingTime,
+
+    @Schema(description = "주간 귀가 시각 통계. value는 KST 기준 00:00부터 지난 분입니다.")
     TimeMetricSection enterHomeTime,
+
+    @Schema(description = "주간 외출 횟수 통계")
     CountMetricSection totalOutingCount,
+
+    @Schema(description = "주간 총 외출 시간 통계. value는 초 단위입니다.")
     DurationMetricSection totalOutingSeconds,
+
+    @Schema(description = "최근 7일 누적 체류 시간 기준 자주 방문한 지역 통계")
     VisitedRegionsSection visitedRegions
 ) {
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticDateRange.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticDateRange.java
@@ -1,0 +1,6 @@
+package backend.capstone.domain.mobility.statics.service;
+
+import java.time.LocalDate;
+
+record StatisticDateRange(LocalDate startDate, LocalDate endDate) {
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticDateRangeCalculator.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticDateRangeCalculator.java
@@ -1,0 +1,22 @@
+package backend.capstone.domain.mobility.statics.service;
+
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final class StatisticDateRangeCalculator {
+
+    static StatisticDateRange calculate(StatisticPeriod period, LocalDate today) {
+        return switch (period) {
+            case WEEK -> new StatisticDateRange(today.minusDays(6), today);
+            case MONTH -> new StatisticDateRange(today.minusDays(29), today);
+            case SIX_MONTHS -> new StatisticDateRange(
+                YearMonth.from(today).minusMonths(5).atDay(1), today);
+            case YEAR -> new StatisticDateRange(
+                YearMonth.from(today).minusMonths(11).atDay(1), today);
+        };
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticMetricService.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticMetricService.java
@@ -11,6 +11,7 @@ import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class StatisticMetricService {
     private static final String OUTING_TIME_METRIC_TYPE = "OUTING_TIME";
     private static final String ENTER_HOME_TIME_METRIC_TYPE = "ENTER_HOME_TIME";
     private static final String TOTAL_OUTING_SECONDS_METRIC_TYPE = "TOTAL_OUTING_SECONDS";
+    private static final String TOTAL_OUTING_COUNT_METRIC_TYPE = "TOTAL_OUTING_COUNT";
     private static final String[] KOREAN_DAY_OF_WEEK_LABELS = {"월", "화", "수", "목", "금", "토", "일"};
 
     private final DayRouteRepository dayRouteRepository;
@@ -34,11 +36,13 @@ public class StatisticMetricService {
         return getMetric(userId, period, today, new MetricConfig(
             OUTING_TIME_METRIC_TYPE,
             "외출",
-            "외출 시간",
+            "외출 시간을",
+            "외출 시간이",
             "빨라졌어요.",
             "늦어졌어요.",
             dayRoute -> TimeFormatUtils.toKstMinutesOfDay(dayRoute.getOutingTime()),
-            value -> TimeFormatUtils.formatHourMinute(value)
+            average -> Math.toIntExact(Math.round(average)),
+            value -> TimeFormatUtils.formatHourMinute(value.intValue())
         ));
     }
 
@@ -48,11 +52,13 @@ public class StatisticMetricService {
         return getMetric(userId, period, today, new MetricConfig(
             ENTER_HOME_TIME_METRIC_TYPE,
             "귀가",
-            "귀가 시각",
+            "귀가 시각을",
+            "귀가 시각이",
             "빨라졌어요.",
             "늦어졌어요.",
             dayRoute -> TimeFormatUtils.toKstMinutesOfDay(dayRoute.getEnterHomeTime()),
-            value -> TimeFormatUtils.formatHourMinute(value)
+            average -> Math.toIntExact(Math.round(average)),
+            value -> TimeFormatUtils.formatHourMinute(value.intValue())
         ));
     }
 
@@ -62,11 +68,29 @@ public class StatisticMetricService {
         return getMetric(userId, period, today, new MetricConfig(
             TOTAL_OUTING_SECONDS_METRIC_TYPE,
             "외출시간",
-            "외출시간",
+            "외출시간을",
+            "외출시간이",
             "줄었어요.",
             "늘었어요.",
             dayRoute -> dayRoute.getTotalOutingSeconds(),
-            value -> DurationFormatUtils.formatOutingDurationText(value)
+            average -> Math.toIntExact(Math.round(average)),
+            value -> DurationFormatUtils.formatOutingDurationText(value.longValue())
+        ));
+    }
+
+    @Transactional(readOnly = true)
+    public StatisticMetricResponse getTotalOutingCountMetric(Long userId, StatisticPeriod period,
+        LocalDate today) {
+        return getMetric(userId, period, today, new MetricConfig(
+            TOTAL_OUTING_COUNT_METRIC_TYPE,
+            "외출횟수",
+            "외출횟수를",
+            "외출횟수가",
+            "줄었어요.",
+            "늘었어요.",
+            dayRoute -> (long) dayRoute.getTotalOutingCount(),
+            average -> roundToOneDecimal(average),
+            value -> String.format(Locale.US, "%.1f회", value.doubleValue())
         ));
     }
 
@@ -135,7 +159,7 @@ public class StatisticMetricService {
 
     private StatisticMetricResponse.StatisticMetricAverage createAverage(List<DayRoute> dayRoutes,
         MetricConfig config) {
-        AverageResult averageResult = calculateAverage(dayRoutes, config.valueExtractor());
+        AverageResult averageResult = calculateAverage(dayRoutes, config);
         return new StatisticMetricResponse.StatisticMetricAverage(
             averageResult.value(),
             averageResult.value() == null ? null : config.displayFormatter().apply(
@@ -188,20 +212,21 @@ public class StatisticMetricService {
         StatisticMetricResponse.StatisticMetricAverage previousAverage,
         MetricConfig config) {
         if (currentAverage.value() == null || previousAverage.value() == null) {
-            return highlightPeriodInfo.currentLabel() + " 평균 " + config.messageMetricName() + "을 "
+            return highlightPeriodInfo.currentLabel() + " 평균 " + config.objectMetricName() + " "
                 + highlightPeriodInfo.previousCompareWithLabel() + " 비교할 기록이 부족해요.";
         }
 
-        int difference = currentAverage.value() - previousAverage.value();
+        double difference = currentAverage.value().doubleValue()
+            - previousAverage.value().doubleValue();
         if (difference < 0) {
-            return highlightPeriodInfo.currentLabel() + " 평균 " + config.messageMetricName() + "이 "
+            return highlightPeriodInfo.currentLabel() + " 평균 " + config.subjectMetricName() + " "
                 + highlightPeriodInfo.previousCompareThanLabel() + " " + config.decreaseMessage();
         }
         if (difference > 0) {
-            return highlightPeriodInfo.currentLabel() + " 평균 " + config.messageMetricName() + "이 "
+            return highlightPeriodInfo.currentLabel() + " 평균 " + config.subjectMetricName() + " "
                 + highlightPeriodInfo.previousCompareThanLabel() + " " + config.increaseMessage();
         }
-        return highlightPeriodInfo.currentLabel() + " 평균 " + config.messageMetricName() + "이 "
+        return highlightPeriodInfo.currentLabel() + " 평균 " + config.subjectMetricName() + " "
             + highlightPeriodInfo.previousCompareWithLabel() + " 같아요.";
     }
 
@@ -221,8 +246,8 @@ public class StatisticMetricService {
         List<StatisticMetricResponse.StatisticMetricBarItem> bars = new ArrayList<>();
         for (StatisticBucket bucket : buckets) {
             List<DayRoute> bucketDayRoutes = findDayRoutesInBucket(bucket, dayRouteMap);
-            AverageResult averageResult = calculateAverage(bucketDayRoutes, config.valueExtractor());
-            Integer value = averageResult.value();
+            AverageResult averageResult = calculateAverage(bucketDayRoutes, config);
+            Number value = averageResult.value();
             bars.add(new StatisticMetricResponse.StatisticMetricBarItem(
                 bucket.label(),
                 bucket.startDate(),
@@ -249,12 +274,11 @@ public class StatisticMetricService {
         return dayRoutes;
     }
 
-    private AverageResult calculateAverage(List<DayRoute> dayRoutes,
-        Function<DayRoute, Long> valueExtractor) {
+    private AverageResult calculateAverage(List<DayRoute> dayRoutes, MetricConfig config) {
         long totalValue = 0L;
         int sampleSize = 0;
         for (DayRoute dayRoute : dayRoutes) {
-            Long value = valueExtractor.apply(dayRoute);
+            Long value = config.valueExtractor().apply(dayRoute);
             if (value == null) {
                 continue;
             }
@@ -262,10 +286,14 @@ public class StatisticMetricService {
             sampleSize++;
         }
 
-        Integer value = sampleSize == 0
+        Number value = sampleSize == 0
             ? null
-            : Math.toIntExact(Math.round((double) totalValue / sampleSize));
+            : config.averageFormatter().apply((double) totalValue / sampleSize);
         return new AverageResult(value, sampleSize);
+    }
+
+    private static double roundToOneDecimal(double value) {
+        return Math.round(value * 10.0) / 10.0;
     }
 
     private String toKoreanDayOfWeekLabel(LocalDate date) {
@@ -278,11 +306,13 @@ public class StatisticMetricService {
     private record MetricConfig(
         String metricType,
         String titleMetricName,
-        String messageMetricName,
+        String objectMetricName,
+        String subjectMetricName,
         String decreaseMessage,
         String increaseMessage,
         Function<DayRoute, Long> valueExtractor,
-        Function<Integer, String> displayFormatter
+        Function<Double, Number> averageFormatter,
+        Function<Number, String> displayFormatter
     ) {
     }
 
@@ -297,6 +327,6 @@ public class StatisticMetricService {
     ) {
     }
 
-    private record AverageResult(Integer value, int sampleSize) {
+    private record AverageResult(Number value, int sampleSize) {
     }
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticMetricService.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticMetricService.java
@@ -4,8 +4,8 @@ import backend.capstone.domain.mobility.dayroute.entity.DayRoute;
 import backend.capstone.domain.mobility.dayroute.repository.DayRouteRepository;
 import backend.capstone.domain.mobility.statics.dto.StatisticMetricResponse;
 import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import backend.capstone.global.util.DurationFormatUtils;
 import backend.capstone.global.util.TimeFormatUtils;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -23,6 +23,7 @@ public class StatisticMetricService {
 
     private static final String OUTING_TIME_METRIC_TYPE = "OUTING_TIME";
     private static final String ENTER_HOME_TIME_METRIC_TYPE = "ENTER_HOME_TIME";
+    private static final String TOTAL_OUTING_SECONDS_METRIC_TYPE = "TOTAL_OUTING_SECONDS";
     private static final String[] KOREAN_DAY_OF_WEEK_LABELS = {"월", "화", "수", "목", "금", "토", "일"};
 
     private final DayRouteRepository dayRouteRepository;
@@ -30,34 +31,54 @@ public class StatisticMetricService {
     @Transactional(readOnly = true)
     public StatisticMetricResponse getOutingTimeMetric(Long userId, StatisticPeriod period,
         LocalDate today) {
-        return getTimeMetric(userId, period, today, new TimeMetricConfig(
+        return getMetric(userId, period, today, new MetricConfig(
             OUTING_TIME_METRIC_TYPE,
             "외출",
             "외출 시간",
-            DayRoute::getOutingTime
+            "빨라졌어요.",
+            "늦어졌어요.",
+            dayRoute -> TimeFormatUtils.toKstMinutesOfDay(dayRoute.getOutingTime()),
+            value -> TimeFormatUtils.formatHourMinute(value)
         ));
     }
 
     @Transactional(readOnly = true)
     public StatisticMetricResponse getEnterHomeTimeMetric(Long userId, StatisticPeriod period,
         LocalDate today) {
-        return getTimeMetric(userId, period, today, new TimeMetricConfig(
+        return getMetric(userId, period, today, new MetricConfig(
             ENTER_HOME_TIME_METRIC_TYPE,
             "귀가",
             "귀가 시각",
-            DayRoute::getEnterHomeTime
+            "빨라졌어요.",
+            "늦어졌어요.",
+            dayRoute -> TimeFormatUtils.toKstMinutesOfDay(dayRoute.getEnterHomeTime()),
+            value -> TimeFormatUtils.formatHourMinute(value)
         ));
     }
 
-    private StatisticMetricResponse getTimeMetric(Long userId, StatisticPeriod period,
-        LocalDate today, TimeMetricConfig config) {
+    @Transactional(readOnly = true)
+    public StatisticMetricResponse getTotalOutingSecondsMetric(Long userId, StatisticPeriod period,
+        LocalDate today) {
+        return getMetric(userId, period, today, new MetricConfig(
+            TOTAL_OUTING_SECONDS_METRIC_TYPE,
+            "외출시간",
+            "외출시간",
+            "줄었어요.",
+            "늘었어요.",
+            dayRoute -> dayRoute.getTotalOutingSeconds(),
+            value -> DurationFormatUtils.formatOutingDurationText(value)
+        ));
+    }
+
+    private StatisticMetricResponse getMetric(Long userId, StatisticPeriod period, LocalDate today,
+        MetricConfig config) {
         List<StatisticBucket> buckets = createBuckets(period, today);
         LocalDate startDate = buckets.getFirst().startDate();
         LocalDate endDate = buckets.getLast().endDate();
         List<DayRoute> dayRoutes = dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(
             userId, startDate, endDate);
         StatisticMetricResponse.StatisticMetricAverage average = createAverage(dayRoutes,
-            config.timeExtractor());
+            config);
 
         return new StatisticMetricResponse(
             config.metricType(),
@@ -65,7 +86,7 @@ public class StatisticMetricService {
             startDate,
             endDate,
             average,
-            createBars(buckets, groupByDate(dayRoutes), config.timeExtractor()),
+            createBars(buckets, groupByDate(dayRoutes), config),
             createHighlight(userId, period, startDate, average, config)
         );
     }
@@ -113,11 +134,11 @@ public class StatisticMetricService {
     }
 
     private StatisticMetricResponse.StatisticMetricAverage createAverage(List<DayRoute> dayRoutes,
-        Function<DayRoute, Instant> timeExtractor) {
-        AverageResult averageResult = calculateAverageMinutes(dayRoutes, timeExtractor);
+        MetricConfig config) {
+        AverageResult averageResult = calculateAverage(dayRoutes, config.valueExtractor());
         return new StatisticMetricResponse.StatisticMetricAverage(
             averageResult.value(),
-            averageResult.value() == null ? null : TimeFormatUtils.formatHourMinute(
+            averageResult.value() == null ? null : config.displayFormatter().apply(
                 averageResult.value()),
             averageResult.sampleSize()
         );
@@ -125,18 +146,18 @@ public class StatisticMetricService {
 
     private StatisticMetricResponse.StatisticMetricHighlight createHighlight(Long userId,
         StatisticPeriod period, LocalDate startDate,
-        StatisticMetricResponse.StatisticMetricAverage currentAverage, TimeMetricConfig config) {
+        StatisticMetricResponse.StatisticMetricAverage currentAverage, MetricConfig config) {
         HighlightPeriodInfo highlightPeriodInfo = createHighlightPeriodInfo(period, startDate,
             config.titleMetricName());
         List<DayRoute> previousDayRoutes = dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(
             userId, highlightPeriodInfo.previousStartDate(), highlightPeriodInfo.previousEndDate());
         StatisticMetricResponse.StatisticMetricAverage previousAverage = createAverage(
-            previousDayRoutes, config.timeExtractor());
+            previousDayRoutes, config);
 
         return new StatisticMetricResponse.StatisticMetricHighlight(
             highlightPeriodInfo.title(),
             createHighlightMessage(highlightPeriodInfo, currentAverage, previousAverage,
-                config.messageMetricName()),
+                config),
             toHighlightMetricValue(highlightPeriodInfo.currentLabel(), currentAverage),
             toHighlightMetricValue(highlightPeriodInfo.previousLabel(), previousAverage)
         );
@@ -165,22 +186,22 @@ public class StatisticMetricService {
         HighlightPeriodInfo highlightPeriodInfo,
         StatisticMetricResponse.StatisticMetricAverage currentAverage,
         StatisticMetricResponse.StatisticMetricAverage previousAverage,
-        String messageMetricName) {
+        MetricConfig config) {
         if (currentAverage.value() == null || previousAverage.value() == null) {
-            return highlightPeriodInfo.currentLabel() + " 평균 " + messageMetricName + "을 "
+            return highlightPeriodInfo.currentLabel() + " 평균 " + config.messageMetricName() + "을 "
                 + highlightPeriodInfo.previousCompareWithLabel() + " 비교할 기록이 부족해요.";
         }
 
         int difference = currentAverage.value() - previousAverage.value();
         if (difference < 0) {
-            return highlightPeriodInfo.currentLabel() + " 평균 " + messageMetricName + "이 "
-                + highlightPeriodInfo.previousCompareThanLabel() + " 빨라졌어요.";
+            return highlightPeriodInfo.currentLabel() + " 평균 " + config.messageMetricName() + "이 "
+                + highlightPeriodInfo.previousCompareThanLabel() + " " + config.decreaseMessage();
         }
         if (difference > 0) {
-            return highlightPeriodInfo.currentLabel() + " 평균 " + messageMetricName + "이 "
-                + highlightPeriodInfo.previousCompareThanLabel() + " 늦어졌어요.";
+            return highlightPeriodInfo.currentLabel() + " 평균 " + config.messageMetricName() + "이 "
+                + highlightPeriodInfo.previousCompareThanLabel() + " " + config.increaseMessage();
         }
-        return highlightPeriodInfo.currentLabel() + " 평균 " + messageMetricName + "이 "
+        return highlightPeriodInfo.currentLabel() + " 평균 " + config.messageMetricName() + "이 "
             + highlightPeriodInfo.previousCompareWithLabel() + " 같아요.";
     }
 
@@ -195,20 +216,19 @@ public class StatisticMetricService {
     }
 
     private List<StatisticMetricResponse.StatisticMetricBarItem> createBars(
-        List<StatisticBucket> buckets, Map<LocalDate, DayRoute> dayRouteMap,
-        Function<DayRoute, Instant> timeExtractor
+        List<StatisticBucket> buckets, Map<LocalDate, DayRoute> dayRouteMap, MetricConfig config
     ) {
         List<StatisticMetricResponse.StatisticMetricBarItem> bars = new ArrayList<>();
         for (StatisticBucket bucket : buckets) {
             List<DayRoute> bucketDayRoutes = findDayRoutesInBucket(bucket, dayRouteMap);
-            AverageResult averageResult = calculateAverageMinutes(bucketDayRoutes, timeExtractor);
+            AverageResult averageResult = calculateAverage(bucketDayRoutes, config.valueExtractor());
             Integer value = averageResult.value();
             bars.add(new StatisticMetricResponse.StatisticMetricBarItem(
                 bucket.label(),
                 bucket.startDate(),
                 bucket.endDate(),
                 value,
-                value == null ? null : TimeFormatUtils.formatHourMinute(value),
+                value == null ? null : config.displayFormatter().apply(value),
                 value != null,
                 averageResult.sampleSize()
             ));
@@ -229,22 +249,22 @@ public class StatisticMetricService {
         return dayRoutes;
     }
 
-    private AverageResult calculateAverageMinutes(List<DayRoute> dayRoutes,
-        Function<DayRoute, Instant> timeExtractor) {
-        long totalMinutes = 0L;
+    private AverageResult calculateAverage(List<DayRoute> dayRoutes,
+        Function<DayRoute, Long> valueExtractor) {
+        long totalValue = 0L;
         int sampleSize = 0;
         for (DayRoute dayRoute : dayRoutes) {
-            Long minutesOfDay = TimeFormatUtils.toKstMinutesOfDay(timeExtractor.apply(dayRoute));
-            if (minutesOfDay == null) {
+            Long value = valueExtractor.apply(dayRoute);
+            if (value == null) {
                 continue;
             }
-            totalMinutes += minutesOfDay;
+            totalValue += value;
             sampleSize++;
         }
 
         Integer value = sampleSize == 0
             ? null
-            : Math.toIntExact(Math.round((double) totalMinutes / sampleSize));
+            : Math.toIntExact(Math.round((double) totalValue / sampleSize));
         return new AverageResult(value, sampleSize);
     }
 
@@ -255,11 +275,14 @@ public class StatisticMetricService {
     private record StatisticBucket(String label, LocalDate startDate, LocalDate endDate) {
     }
 
-    private record TimeMetricConfig(
+    private record MetricConfig(
         String metricType,
         String titleMetricName,
         String messageMetricName,
-        Function<DayRoute, Instant> timeExtractor
+        String decreaseMessage,
+        String increaseMessage,
+        Function<DayRoute, Long> valueExtractor,
+        Function<Integer, String> displayFormatter
     ) {
     }
 

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticMetricService.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticMetricService.java
@@ -1,0 +1,239 @@
+package backend.capstone.domain.mobility.statics.service;
+
+import backend.capstone.domain.mobility.dayroute.entity.DayRoute;
+import backend.capstone.domain.mobility.dayroute.repository.DayRouteRepository;
+import backend.capstone.domain.mobility.statics.dto.StatisticMetricResponse;
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import backend.capstone.global.util.TimeFormatUtils;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticMetricService {
+
+    private static final String OUTING_TIME_METRIC_TYPE = "OUTING_TIME";
+    private static final String[] KOREAN_DAY_OF_WEEK_LABELS = {"월", "화", "수", "목", "금", "토", "일"};
+
+    private final DayRouteRepository dayRouteRepository;
+
+    @Transactional(readOnly = true)
+    public StatisticMetricResponse getOutingTimeMetric(Long userId, StatisticPeriod period,
+        LocalDate today) {
+        List<StatisticBucket> buckets = createBuckets(period, today);
+        LocalDate startDate = buckets.getFirst().startDate();
+        LocalDate endDate = buckets.getLast().endDate();
+        List<DayRoute> dayRoutes = dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(
+            userId, startDate, endDate);
+        StatisticMetricResponse.StatisticMetricAverage average = createAverage(dayRoutes);
+
+        return new StatisticMetricResponse(
+            OUTING_TIME_METRIC_TYPE,
+            period,
+            startDate,
+            endDate,
+            average,
+            createBars(buckets, groupByDate(dayRoutes)),
+            createHighlight(userId, period, startDate, average)
+        );
+    }
+
+    private List<StatisticBucket> createBuckets(StatisticPeriod period, LocalDate today) {
+        return switch (period) {
+            case WEEK -> createDailyBuckets(today.minusDays(6), today, true);
+            case MONTH -> createDailyBuckets(today.minusDays(29), today, false);
+            case SIX_MONTHS -> createMonthlyBuckets(today, 6);
+            case YEAR -> createMonthlyBuckets(today, 12);
+        };
+    }
+
+    private List<StatisticBucket> createDailyBuckets(LocalDate startDate, LocalDate endDate,
+        boolean useDayOfWeekLabel) {
+        List<StatisticBucket> buckets = new ArrayList<>();
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            String label = useDayOfWeekLabel ? toKoreanDayOfWeekLabel(date) : String.valueOf(
+                date.getDayOfMonth());
+            buckets.add(new StatisticBucket(label, date, date));
+        }
+        return buckets;
+    }
+
+    private List<StatisticBucket> createMonthlyBuckets(LocalDate today, int monthCount) {
+        List<StatisticBucket> buckets = new ArrayList<>();
+        YearMonth startMonth = YearMonth.from(today).minusMonths(monthCount - 1L);
+        for (int index = 0; index < monthCount; index++) {
+            YearMonth yearMonth = startMonth.plusMonths(index);
+            LocalDate startDate = yearMonth.atDay(1);
+            LocalDate endDate = yearMonth.equals(YearMonth.from(today))
+                ? today
+                : yearMonth.atEndOfMonth();
+            buckets.add(new StatisticBucket(yearMonth.getMonthValue() + "월", startDate, endDate));
+        }
+        return buckets;
+    }
+
+    private Map<LocalDate, DayRoute> groupByDate(List<DayRoute> dayRoutes) {
+        Map<LocalDate, DayRoute> dayRouteMap = new LinkedHashMap<>();
+        for (DayRoute dayRoute : dayRoutes) {
+            dayRouteMap.put(dayRoute.getDate(), dayRoute);
+        }
+        return dayRouteMap;
+    }
+
+    private StatisticMetricResponse.StatisticMetricAverage createAverage(List<DayRoute> dayRoutes) {
+        AverageResult averageResult = calculateAverageMinutes(dayRoutes);
+        return new StatisticMetricResponse.StatisticMetricAverage(
+            averageResult.value(),
+            averageResult.value() == null ? null : TimeFormatUtils.formatHourMinute(
+                averageResult.value()),
+            averageResult.sampleSize()
+        );
+    }
+
+    private StatisticMetricResponse.StatisticMetricHighlight createHighlight(Long userId,
+        StatisticPeriod period, LocalDate startDate,
+        StatisticMetricResponse.StatisticMetricAverage currentAverage) {
+        HighlightPeriodInfo highlightPeriodInfo = createHighlightPeriodInfo(period, startDate);
+        List<DayRoute> previousDayRoutes = dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(
+            userId, highlightPeriodInfo.previousStartDate(), highlightPeriodInfo.previousEndDate());
+        StatisticMetricResponse.StatisticMetricAverage previousAverage = createAverage(
+            previousDayRoutes);
+
+        return new StatisticMetricResponse.StatisticMetricHighlight(
+            highlightPeriodInfo.title(),
+            createHighlightMessage(highlightPeriodInfo, currentAverage, previousAverage),
+            toHighlightMetricValue(highlightPeriodInfo.currentLabel(), currentAverage),
+            toHighlightMetricValue(highlightPeriodInfo.previousLabel(), previousAverage)
+        );
+    }
+
+    private HighlightPeriodInfo createHighlightPeriodInfo(StatisticPeriod period,
+        LocalDate startDate) {
+        return switch (period) {
+            case WEEK -> new HighlightPeriodInfo(
+                "이번 주 외출", "이번 주", "지난주", "지난주와", "지난주보다",
+                startDate.minusDays(7), startDate.minusDays(1));
+            case MONTH -> new HighlightPeriodInfo(
+                "이번 달 외출", "이번 달", "지난달", "지난달과", "지난달보다",
+                startDate.minusDays(30), startDate.minusDays(1));
+            case SIX_MONTHS -> new HighlightPeriodInfo(
+                "최근 6개월 외출", "최근 6개월", "이전 6개월", "이전 6개월과", "이전 6개월보다",
+                startDate.minusMonths(6), startDate.minusDays(1));
+            case YEAR -> new HighlightPeriodInfo(
+                "최근 1년 외출", "최근 1년", "이전 1년", "이전 1년과", "이전 1년보다",
+                startDate.minusYears(1), startDate.minusDays(1));
+        };
+    }
+
+    private String createHighlightMessage(
+        HighlightPeriodInfo highlightPeriodInfo,
+        StatisticMetricResponse.StatisticMetricAverage currentAverage,
+        StatisticMetricResponse.StatisticMetricAverage previousAverage) {
+        if (currentAverage.value() == null || previousAverage.value() == null) {
+            return highlightPeriodInfo.currentLabel() + " 평균 외출 시간을 "
+                + highlightPeriodInfo.previousCompareWithLabel() + " 비교할 기록이 부족해요.";
+        }
+
+        int difference = currentAverage.value() - previousAverage.value();
+        if (difference < 0) {
+            return highlightPeriodInfo.currentLabel() + " 평균 외출 시간이 "
+                + highlightPeriodInfo.previousCompareThanLabel() + " 빨라졌어요.";
+        }
+        if (difference > 0) {
+            return highlightPeriodInfo.currentLabel() + " 평균 외출 시간이 "
+                + highlightPeriodInfo.previousCompareThanLabel() + " 늦어졌어요.";
+        }
+        return highlightPeriodInfo.currentLabel() + " 평균 외출 시간이 "
+            + highlightPeriodInfo.previousCompareWithLabel() + " 같아요.";
+    }
+
+    private StatisticMetricResponse.HighlightMetricValue toHighlightMetricValue(String label,
+        StatisticMetricResponse.StatisticMetricAverage average) {
+        return new StatisticMetricResponse.HighlightMetricValue(
+            label,
+            average.value(),
+            average.displayText(),
+            average.sampleSize()
+        );
+    }
+
+    private List<StatisticMetricResponse.StatisticMetricBarItem> createBars(
+        List<StatisticBucket> buckets, Map<LocalDate, DayRoute> dayRouteMap
+    ) {
+        List<StatisticMetricResponse.StatisticMetricBarItem> bars = new ArrayList<>();
+        for (StatisticBucket bucket : buckets) {
+            List<DayRoute> bucketDayRoutes = findDayRoutesInBucket(bucket, dayRouteMap);
+            AverageResult averageResult = calculateAverageMinutes(bucketDayRoutes);
+            Integer value = averageResult.value();
+            bars.add(new StatisticMetricResponse.StatisticMetricBarItem(
+                bucket.label(),
+                bucket.startDate(),
+                bucket.endDate(),
+                value,
+                value == null ? null : TimeFormatUtils.formatHourMinute(value),
+                value != null,
+                averageResult.sampleSize()
+            ));
+        }
+        return bars;
+    }
+
+    private List<DayRoute> findDayRoutesInBucket(StatisticBucket bucket,
+        Map<LocalDate, DayRoute> dayRouteMap) {
+        List<DayRoute> dayRoutes = new ArrayList<>();
+        for (LocalDate date = bucket.startDate(); !date.isAfter(bucket.endDate());
+            date = date.plusDays(1)) {
+            DayRoute dayRoute = dayRouteMap.get(date);
+            if (dayRoute != null) {
+                dayRoutes.add(dayRoute);
+            }
+        }
+        return dayRoutes;
+    }
+
+    private AverageResult calculateAverageMinutes(List<DayRoute> dayRoutes) {
+        long totalMinutes = 0L;
+        int sampleSize = 0;
+        for (DayRoute dayRoute : dayRoutes) {
+            Long minutesOfDay = TimeFormatUtils.toKstMinutesOfDay(dayRoute.getOutingTime());
+            if (minutesOfDay == null) {
+                continue;
+            }
+            totalMinutes += minutesOfDay;
+            sampleSize++;
+        }
+
+        Integer value = sampleSize == 0
+            ? null
+            : Math.toIntExact(Math.round((double) totalMinutes / sampleSize));
+        return new AverageResult(value, sampleSize);
+    }
+
+    private String toKoreanDayOfWeekLabel(LocalDate date) {
+        return KOREAN_DAY_OF_WEEK_LABELS[date.getDayOfWeek().getValue() - 1];
+    }
+
+    private record StatisticBucket(String label, LocalDate startDate, LocalDate endDate) {
+    }
+
+    private record HighlightPeriodInfo(
+        String title,
+        String currentLabel,
+        String previousLabel,
+        String previousCompareWithLabel,
+        String previousCompareThanLabel,
+        LocalDate previousStartDate,
+        LocalDate previousEndDate
+    ) {
+    }
+
+    private record AverageResult(Integer value, int sampleSize) {
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticMetricService.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticMetricService.java
@@ -5,12 +5,14 @@ import backend.capstone.domain.mobility.dayroute.repository.DayRouteRepository;
 import backend.capstone.domain.mobility.statics.dto.StatisticMetricResponse;
 import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
 import backend.capstone.global.util.TimeFormatUtils;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class StatisticMetricService {
 
     private static final String OUTING_TIME_METRIC_TYPE = "OUTING_TIME";
+    private static final String ENTER_HOME_TIME_METRIC_TYPE = "ENTER_HOME_TIME";
     private static final String[] KOREAN_DAY_OF_WEEK_LABELS = {"월", "화", "수", "목", "금", "토", "일"};
 
     private final DayRouteRepository dayRouteRepository;
@@ -27,21 +30,43 @@ public class StatisticMetricService {
     @Transactional(readOnly = true)
     public StatisticMetricResponse getOutingTimeMetric(Long userId, StatisticPeriod period,
         LocalDate today) {
+        return getTimeMetric(userId, period, today, new TimeMetricConfig(
+            OUTING_TIME_METRIC_TYPE,
+            "외출",
+            "외출 시간",
+            DayRoute::getOutingTime
+        ));
+    }
+
+    @Transactional(readOnly = true)
+    public StatisticMetricResponse getEnterHomeTimeMetric(Long userId, StatisticPeriod period,
+        LocalDate today) {
+        return getTimeMetric(userId, period, today, new TimeMetricConfig(
+            ENTER_HOME_TIME_METRIC_TYPE,
+            "귀가",
+            "귀가 시각",
+            DayRoute::getEnterHomeTime
+        ));
+    }
+
+    private StatisticMetricResponse getTimeMetric(Long userId, StatisticPeriod period,
+        LocalDate today, TimeMetricConfig config) {
         List<StatisticBucket> buckets = createBuckets(period, today);
         LocalDate startDate = buckets.getFirst().startDate();
         LocalDate endDate = buckets.getLast().endDate();
         List<DayRoute> dayRoutes = dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(
             userId, startDate, endDate);
-        StatisticMetricResponse.StatisticMetricAverage average = createAverage(dayRoutes);
+        StatisticMetricResponse.StatisticMetricAverage average = createAverage(dayRoutes,
+            config.timeExtractor());
 
         return new StatisticMetricResponse(
-            OUTING_TIME_METRIC_TYPE,
+            config.metricType(),
             period,
             startDate,
             endDate,
             average,
-            createBars(buckets, groupByDate(dayRoutes)),
-            createHighlight(userId, period, startDate, average)
+            createBars(buckets, groupByDate(dayRoutes), config.timeExtractor()),
+            createHighlight(userId, period, startDate, average, config)
         );
     }
 
@@ -87,8 +112,9 @@ public class StatisticMetricService {
         return dayRouteMap;
     }
 
-    private StatisticMetricResponse.StatisticMetricAverage createAverage(List<DayRoute> dayRoutes) {
-        AverageResult averageResult = calculateAverageMinutes(dayRoutes);
+    private StatisticMetricResponse.StatisticMetricAverage createAverage(List<DayRoute> dayRoutes,
+        Function<DayRoute, Instant> timeExtractor) {
+        AverageResult averageResult = calculateAverageMinutes(dayRoutes, timeExtractor);
         return new StatisticMetricResponse.StatisticMetricAverage(
             averageResult.value(),
             averageResult.value() == null ? null : TimeFormatUtils.formatHourMinute(
@@ -99,35 +125,38 @@ public class StatisticMetricService {
 
     private StatisticMetricResponse.StatisticMetricHighlight createHighlight(Long userId,
         StatisticPeriod period, LocalDate startDate,
-        StatisticMetricResponse.StatisticMetricAverage currentAverage) {
-        HighlightPeriodInfo highlightPeriodInfo = createHighlightPeriodInfo(period, startDate);
+        StatisticMetricResponse.StatisticMetricAverage currentAverage, TimeMetricConfig config) {
+        HighlightPeriodInfo highlightPeriodInfo = createHighlightPeriodInfo(period, startDate,
+            config.titleMetricName());
         List<DayRoute> previousDayRoutes = dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(
             userId, highlightPeriodInfo.previousStartDate(), highlightPeriodInfo.previousEndDate());
         StatisticMetricResponse.StatisticMetricAverage previousAverage = createAverage(
-            previousDayRoutes);
+            previousDayRoutes, config.timeExtractor());
 
         return new StatisticMetricResponse.StatisticMetricHighlight(
             highlightPeriodInfo.title(),
-            createHighlightMessage(highlightPeriodInfo, currentAverage, previousAverage),
+            createHighlightMessage(highlightPeriodInfo, currentAverage, previousAverage,
+                config.messageMetricName()),
             toHighlightMetricValue(highlightPeriodInfo.currentLabel(), currentAverage),
             toHighlightMetricValue(highlightPeriodInfo.previousLabel(), previousAverage)
         );
     }
 
     private HighlightPeriodInfo createHighlightPeriodInfo(StatisticPeriod period,
-        LocalDate startDate) {
+        LocalDate startDate, String titleMetricName) {
         return switch (period) {
             case WEEK -> new HighlightPeriodInfo(
-                "이번 주 외출", "이번 주", "지난주", "지난주와", "지난주보다",
+                "이번 주 " + titleMetricName, "이번 주", "지난주", "지난주와", "지난주보다",
                 startDate.minusDays(7), startDate.minusDays(1));
             case MONTH -> new HighlightPeriodInfo(
-                "이번 달 외출", "이번 달", "지난달", "지난달과", "지난달보다",
+                "이번 달 " + titleMetricName, "이번 달", "지난달", "지난달과", "지난달보다",
                 startDate.minusDays(30), startDate.minusDays(1));
             case SIX_MONTHS -> new HighlightPeriodInfo(
-                "최근 6개월 외출", "최근 6개월", "이전 6개월", "이전 6개월과", "이전 6개월보다",
+                "최근 6개월 " + titleMetricName, "최근 6개월", "이전 6개월", "이전 6개월과",
+                "이전 6개월보다",
                 startDate.minusMonths(6), startDate.minusDays(1));
             case YEAR -> new HighlightPeriodInfo(
-                "최근 1년 외출", "최근 1년", "이전 1년", "이전 1년과", "이전 1년보다",
+                "최근 1년 " + titleMetricName, "최근 1년", "이전 1년", "이전 1년과", "이전 1년보다",
                 startDate.minusYears(1), startDate.minusDays(1));
         };
     }
@@ -135,22 +164,23 @@ public class StatisticMetricService {
     private String createHighlightMessage(
         HighlightPeriodInfo highlightPeriodInfo,
         StatisticMetricResponse.StatisticMetricAverage currentAverage,
-        StatisticMetricResponse.StatisticMetricAverage previousAverage) {
+        StatisticMetricResponse.StatisticMetricAverage previousAverage,
+        String messageMetricName) {
         if (currentAverage.value() == null || previousAverage.value() == null) {
-            return highlightPeriodInfo.currentLabel() + " 평균 외출 시간을 "
+            return highlightPeriodInfo.currentLabel() + " 평균 " + messageMetricName + "을 "
                 + highlightPeriodInfo.previousCompareWithLabel() + " 비교할 기록이 부족해요.";
         }
 
         int difference = currentAverage.value() - previousAverage.value();
         if (difference < 0) {
-            return highlightPeriodInfo.currentLabel() + " 평균 외출 시간이 "
+            return highlightPeriodInfo.currentLabel() + " 평균 " + messageMetricName + "이 "
                 + highlightPeriodInfo.previousCompareThanLabel() + " 빨라졌어요.";
         }
         if (difference > 0) {
-            return highlightPeriodInfo.currentLabel() + " 평균 외출 시간이 "
+            return highlightPeriodInfo.currentLabel() + " 평균 " + messageMetricName + "이 "
                 + highlightPeriodInfo.previousCompareThanLabel() + " 늦어졌어요.";
         }
-        return highlightPeriodInfo.currentLabel() + " 평균 외출 시간이 "
+        return highlightPeriodInfo.currentLabel() + " 평균 " + messageMetricName + "이 "
             + highlightPeriodInfo.previousCompareWithLabel() + " 같아요.";
     }
 
@@ -165,12 +195,13 @@ public class StatisticMetricService {
     }
 
     private List<StatisticMetricResponse.StatisticMetricBarItem> createBars(
-        List<StatisticBucket> buckets, Map<LocalDate, DayRoute> dayRouteMap
+        List<StatisticBucket> buckets, Map<LocalDate, DayRoute> dayRouteMap,
+        Function<DayRoute, Instant> timeExtractor
     ) {
         List<StatisticMetricResponse.StatisticMetricBarItem> bars = new ArrayList<>();
         for (StatisticBucket bucket : buckets) {
             List<DayRoute> bucketDayRoutes = findDayRoutesInBucket(bucket, dayRouteMap);
-            AverageResult averageResult = calculateAverageMinutes(bucketDayRoutes);
+            AverageResult averageResult = calculateAverageMinutes(bucketDayRoutes, timeExtractor);
             Integer value = averageResult.value();
             bars.add(new StatisticMetricResponse.StatisticMetricBarItem(
                 bucket.label(),
@@ -198,11 +229,12 @@ public class StatisticMetricService {
         return dayRoutes;
     }
 
-    private AverageResult calculateAverageMinutes(List<DayRoute> dayRoutes) {
+    private AverageResult calculateAverageMinutes(List<DayRoute> dayRoutes,
+        Function<DayRoute, Instant> timeExtractor) {
         long totalMinutes = 0L;
         int sampleSize = 0;
         for (DayRoute dayRoute : dayRoutes) {
-            Long minutesOfDay = TimeFormatUtils.toKstMinutesOfDay(dayRoute.getOutingTime());
+            Long minutesOfDay = TimeFormatUtils.toKstMinutesOfDay(timeExtractor.apply(dayRoute));
             if (minutesOfDay == null) {
                 continue;
             }
@@ -221,6 +253,14 @@ public class StatisticMetricService {
     }
 
     private record StatisticBucket(String label, LocalDate startDate, LocalDate endDate) {
+    }
+
+    private record TimeMetricConfig(
+        String metricType,
+        String titleMetricName,
+        String messageMetricName,
+        Function<DayRoute, Instant> timeExtractor
+    ) {
     }
 
     private record HighlightPeriodInfo(

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticMetricService.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/service/StatisticMetricService.java
@@ -72,7 +72,7 @@ public class StatisticMetricService {
             "외출시간이",
             "줄었어요.",
             "늘었어요.",
-            dayRoute -> dayRoute.getTotalOutingSeconds(),
+            this::extractTotalOutingSecondsIfOutingRecorded,
             average -> Math.toIntExact(Math.round(average)),
             value -> DurationFormatUtils.formatOutingDurationText(value.longValue())
         ));
@@ -88,7 +88,7 @@ public class StatisticMetricService {
             "외출횟수가",
             "줄었어요.",
             "늘었어요.",
-            dayRoute -> (long) dayRoute.getTotalOutingCount(),
+            this::extractTotalOutingCountIfOutingRecorded,
             average -> roundToOneDecimal(average),
             value -> String.format(Locale.US, "%.1f회", value.doubleValue())
         ));
@@ -290,6 +290,24 @@ public class StatisticMetricService {
             ? null
             : config.averageFormatter().apply((double) totalValue / sampleSize);
         return new AverageResult(value, sampleSize);
+    }
+
+    private Long extractTotalOutingSecondsIfOutingRecorded(DayRoute dayRoute) {
+        if (!hasOutingRecord(dayRoute)) {
+            return null;
+        }
+        return dayRoute.getTotalOutingSeconds();
+    }
+
+    private Long extractTotalOutingCountIfOutingRecorded(DayRoute dayRoute) {
+        if (!hasOutingRecord(dayRoute)) {
+            return null;
+        }
+        return (long) dayRoute.getTotalOutingCount();
+    }
+
+    private boolean hasOutingRecord(DayRoute dayRoute) {
+        return dayRoute.getOutingTime() != null;
     }
 
     private static double roundToOneDecimal(double value) {

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/service/VisitStatisticsService.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/service/VisitStatisticsService.java
@@ -1,0 +1,183 @@
+package backend.capstone.domain.mobility.statics.service;
+
+import backend.capstone.domain.mobility.analysis.visitedregion.entity.VisitedRegion;
+import backend.capstone.domain.mobility.analysis.visitedregion.repository.VisitedRegionRepository;
+import backend.capstone.domain.mobility.place.entity.Place;
+import backend.capstone.domain.mobility.place.repository.PlaceRepository;
+import backend.capstone.domain.mobility.statics.dto.PlaceStatisticsSection;
+import backend.capstone.domain.mobility.statics.dto.VisitStatisticsResponse;
+import backend.capstone.domain.mobility.statics.dto.VisitedRegionStatisticsSection;
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class VisitStatisticsService {
+
+    private static final int REGION_VISIBLE_LIMIT = 3;
+    private static final int PLACE_VISIBLE_LIMIT = 5;
+    private static final String OTHER_REGION_NAME = "그 외";
+
+    private final VisitedRegionRepository visitedRegionRepository;
+    private final PlaceRepository placeRepository;
+
+    @Transactional(readOnly = true)
+    public VisitStatisticsResponse getVisitStatistics(Long userId, StatisticPeriod period,
+        LocalDate today) {
+        StatisticDateRange dateRange = StatisticDateRangeCalculator.calculate(period, today);
+        List<VisitedRegion> visitedRegions = visitedRegionRepository.findByUserIdAndDateBetween(
+            userId, dateRange.startDate(), dateRange.endDate());
+        List<Place> places = placeRepository.findByUserIdAndDateBetween(
+            userId, dateRange.startDate(), dateRange.endDate());
+
+        return new VisitStatisticsResponse(
+            period,
+            dateRange.startDate(),
+            dateRange.endDate(),
+            createVisitedRegionSection(visitedRegions),
+            createPlaceSection(places)
+        );
+    }
+
+    private VisitedRegionStatisticsSection createVisitedRegionSection(
+        List<VisitedRegion> visitedRegions) {
+        Map<String, Integer> visitCountByRegion = new LinkedHashMap<>();
+        for (VisitedRegion visitedRegion : visitedRegions) {
+            String regionName = visitedRegion.getRegion().getDongName();
+            visitCountByRegion.merge(regionName, 1, Integer::sum);
+        }
+
+        List<RegionVisitSummary> summaries = visitCountByRegion.entrySet().stream()
+            .map(entry -> new RegionVisitSummary(entry.getKey(), entry.getValue()))
+            .sorted(Comparator
+                .comparingInt(RegionVisitSummary::visitCount).reversed()
+                .thenComparing(RegionVisitSummary::regionName))
+            .toList();
+
+        int totalVisitCount = summaries.stream()
+            .mapToInt(RegionVisitSummary::visitCount)
+            .sum();
+        List<VisitedRegionStatisticsSection.VisitedRegionStatisticsItem> items =
+            createVisitedRegionItems(summaries, totalVisitCount);
+        return new VisitedRegionStatisticsSection(totalVisitCount, items);
+    }
+
+    private List<VisitedRegionStatisticsSection.VisitedRegionStatisticsItem>
+        createVisitedRegionItems(List<RegionVisitSummary> summaries, int totalVisitCount) {
+        if (totalVisitCount == 0) {
+            return List.of();
+        }
+
+        List<VisitedRegionStatisticsSection.VisitedRegionStatisticsItem> items = new ArrayList<>();
+        int visibleCount = Math.min(REGION_VISIBLE_LIMIT, summaries.size());
+        for (int index = 0; index < visibleCount; index++) {
+            RegionVisitSummary summary = summaries.get(index);
+            items.add(toVisitedRegionItem(index + 1, summary.regionName(), summary.visitCount(),
+                totalVisitCount));
+        }
+
+        int otherVisitCount = summaries.stream()
+            .skip(REGION_VISIBLE_LIMIT)
+            .mapToInt(RegionVisitSummary::visitCount)
+            .sum();
+        if (otherVisitCount > 0) {
+            items.add(toVisitedRegionItem(items.size() + 1, OTHER_REGION_NAME, otherVisitCount,
+                totalVisitCount));
+        }
+        return items;
+    }
+
+    private VisitedRegionStatisticsSection.VisitedRegionStatisticsItem toVisitedRegionItem(
+        int rank, String regionName, int visitCount, int totalVisitCount) {
+        double ratio = roundToOneDecimal((double) visitCount * 100 / totalVisitCount);
+        return new VisitedRegionStatisticsSection.VisitedRegionStatisticsItem(
+            rank,
+            regionName,
+            visitCount,
+            ratio,
+            Math.round(ratio) + "%"
+        );
+    }
+
+    private PlaceStatisticsSection createPlaceSection(List<Place> places) {
+        Map<PlaceKey, PlaceVisitSummary> summaryByPlace = new LinkedHashMap<>();
+        for (Place place : places) {
+            PlaceKey key = new PlaceKey(place.getName(), place.getRoadAddress());
+            summaryByPlace.computeIfAbsent(key,
+                ignored -> new PlaceVisitSummary(place.getName(), place.getRoadAddress()))
+                .increase();
+        }
+
+        List<PlaceVisitSummary> summaries = summaryByPlace.values().stream()
+            .sorted(Comparator
+                .comparingInt(PlaceVisitSummary::visitCount).reversed()
+                .thenComparing(PlaceVisitSummary::placeName,
+                    Comparator.nullsLast(String::compareTo))
+                .thenComparing(PlaceVisitSummary::roadAddress,
+                    Comparator.nullsLast(String::compareTo)))
+            .toList();
+        int totalVisitCount = summaries.stream()
+            .mapToInt(PlaceVisitSummary::visitCount)
+            .sum();
+
+        List<PlaceStatisticsSection.PlaceStatisticsItem> items = new ArrayList<>();
+        int visibleCount = Math.min(PLACE_VISIBLE_LIMIT, summaries.size());
+        for (int index = 0; index < visibleCount; index++) {
+            PlaceVisitSummary summary = summaries.get(index);
+            items.add(new PlaceStatisticsSection.PlaceStatisticsItem(
+                index + 1,
+                summary.placeName(),
+                summary.roadAddress(),
+                summary.visitCount(),
+                summary.visitCount() + "회"
+            ));
+        }
+        return new PlaceStatisticsSection(totalVisitCount, items);
+    }
+
+    private static double roundToOneDecimal(double value) {
+        return Math.round(value * 10.0) / 10.0;
+    }
+
+    private record RegionVisitSummary(String regionName, int visitCount) {
+    }
+
+    private record PlaceKey(String placeName, String roadAddress) {
+    }
+
+    private static final class PlaceVisitSummary {
+
+        private final String placeName;
+        private final String roadAddress;
+        private int visitCount;
+
+        private PlaceVisitSummary(String placeName, String roadAddress) {
+            this.placeName = placeName;
+            this.roadAddress = roadAddress;
+        }
+
+        private void increase() {
+            visitCount++;
+        }
+
+        private String placeName() {
+            return placeName;
+        }
+
+        private String roadAddress() {
+            return roadAddress;
+        }
+
+        private int visitCount() {
+            return visitCount;
+        }
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/service/WeeklyStatisticsService.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/service/WeeklyStatisticsService.java
@@ -164,13 +164,14 @@ public class WeeklyStatisticsService {
             }
         }
 
-        Long averageValue = sampleSize == 0 ? null : Math.round((double) totalSeconds / sampleSize);
+        Double averageValue = sampleSize == 0 ? null
+            : Math.round(((double) totalSeconds / sampleSize) * 10.0) / 10.0;
 
         return new DurationMetricSection(
             new DurationMetricSection.DurationMetricAverage(
                 averageValue,
                 averageValue == null ? null
-                    : DurationFormatUtils.formatOutingDurationText(averageValue),
+                    : DurationFormatUtils.formatOutingDurationText(Math.round(averageValue)),
                 sampleSize
             ),
             dailyValues
@@ -190,7 +191,8 @@ public class WeeklyStatisticsService {
                 .add(visitedRegion));
 
         List<RegionSummary> topRegions = regionSummaryMap.values().stream()
-            .sorted((left, right) -> Long.compare(right.totalStaySeconds(), left.totalStaySeconds()))
+            .sorted(
+                (left, right) -> Long.compare(right.totalStaySeconds(), left.totalStaySeconds()))
             .limit(TOP_REGION_LIMIT)
             .toList();
 
@@ -199,9 +201,7 @@ public class WeeklyStatisticsService {
             RegionSummary regionSummary = topRegions.get(index);
             items.add(new VisitedRegionsSection.VisitedRegionSummaryItem(
                 index + 1,
-                regionSummary.regionName(),
-                regionSummary.totalStaySeconds(),
-                regionSummary.visitDays()
+                regionSummary.regionName()
             ));
         }
 
@@ -225,13 +225,13 @@ public class WeeklyStatisticsService {
     }
 
     private record DailySlot(LocalDate date, DayRoute dayRoute) {
+
     }
 
     private static final class RegionSummary {
 
         private final String regionName;
         private long totalStaySeconds;
-        private int visitDays;
 
         private RegionSummary(String regionName) {
             this.regionName = regionName;
@@ -239,7 +239,6 @@ public class WeeklyStatisticsService {
 
         private void add(VisitedRegion visitedRegion) {
             totalStaySeconds += visitedRegion.getTotalStaySeconds();
-            visitDays++;
         }
 
         private String regionName() {
@@ -250,8 +249,5 @@ public class WeeklyStatisticsService {
             return totalStaySeconds;
         }
 
-        private int visitDays() {
-            return visitDays;
-        }
     }
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/service/WeeklyStatisticsService.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/service/WeeklyStatisticsService.java
@@ -1,0 +1,257 @@
+package backend.capstone.domain.mobility.statics.service;
+
+import backend.capstone.domain.mobility.analysis.visitedregion.entity.VisitedRegion;
+import backend.capstone.domain.mobility.analysis.visitedregion.repository.VisitedRegionRepository;
+import backend.capstone.domain.mobility.dayroute.entity.DayRoute;
+import backend.capstone.domain.mobility.dayroute.repository.DayRouteRepository;
+import backend.capstone.domain.mobility.statics.dto.CountMetricSection;
+import backend.capstone.domain.mobility.statics.dto.DurationMetricSection;
+import backend.capstone.domain.mobility.statics.dto.TimeMetricSection;
+import backend.capstone.domain.mobility.statics.dto.VisitedRegionsSection;
+import backend.capstone.domain.mobility.statics.dto.WeeklyStatisticsResponse;
+import backend.capstone.global.util.DurationFormatUtils;
+import backend.capstone.global.util.TimeFormatUtils;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class WeeklyStatisticsService {
+
+    private static final int RECENT_DAYS = 7;
+    private static final int TOP_REGION_LIMIT = 2;
+
+    private final DayRouteRepository dayRouteRepository;
+    private final VisitedRegionRepository visitedRegionRepository;
+
+    @Transactional(readOnly = true)
+    public WeeklyStatisticsResponse getWeeklyStatistics(Long userId, LocalDate today) {
+        LocalDate endDate = today;
+        LocalDate startDate = endDate.minusDays(RECENT_DAYS - 1L);
+        List<DayRoute> dayRoutes = dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(
+            userId, startDate, endDate);
+        List<DailySlot> dailySlots = createDailySlots(startDate, endDate, dayRoutes);
+
+        return new WeeklyStatisticsResponse(
+            startDate,
+            endDate,
+            buildOutingTimeSection(dailySlots),
+            buildEnterHomeTimeSection(dailySlots),
+            buildTotalOutingCountSection(dailySlots),
+            buildTotalOutingSecondsSection(dailySlots),
+            buildVisitedRegionsSection(dayRoutes)
+        );
+    }
+
+    private List<DailySlot> createDailySlots(LocalDate startDate, LocalDate endDate,
+        List<DayRoute> dayRoutes) {
+        Map<LocalDate, DayRoute> dayRouteMap = new LinkedHashMap<>();
+        for (DayRoute dayRoute : dayRoutes) {
+            dayRouteMap.put(dayRoute.getDate(), dayRoute);
+        }
+
+        List<DailySlot> dailySlots = new ArrayList<>();
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            dailySlots.add(new DailySlot(date, dayRouteMap.get(date)));
+        }
+        return dailySlots;
+    }
+
+    private TimeMetricSection buildOutingTimeSection(List<DailySlot> dailySlots) {
+        return buildTimeMetricSection(dailySlots, DayRoute::getOutingTime);
+    }
+
+    private TimeMetricSection buildEnterHomeTimeSection(List<DailySlot> dailySlots) {
+        return buildTimeMetricSection(dailySlots, DayRoute::getEnterHomeTime);
+    }
+
+    private TimeMetricSection buildTimeMetricSection(List<DailySlot> dailySlots,
+        Function<DayRoute, Instant> extractor) {
+        List<TimeMetricSection.TimeMetricDailyItem> dailyValues = new ArrayList<>();
+        long totalMinutes = 0L;
+        int sampleSize = 0;
+
+        for (DailySlot dailySlot : dailySlots) {
+            Integer minutesOfDay = getMinutesOfDay(dailySlot.dayRoute(), extractor);
+            dailyValues.add(new TimeMetricSection.TimeMetricDailyItem(
+                dailySlot.date(),
+                dailySlot.dayRoute() != null,
+                minutesOfDay,
+                minutesOfDay == null ? null : TimeFormatUtils.formatHourMinute(minutesOfDay)
+            ));
+
+            if (minutesOfDay != null) {
+                totalMinutes += minutesOfDay;
+                sampleSize++;
+            }
+        }
+
+        Integer averageValue = sampleSize == 0
+            ? null
+            : Math.toIntExact(Math.round((double) totalMinutes / sampleSize));
+
+        return new TimeMetricSection(
+            new TimeMetricSection.TimeMetricAverage(
+                averageValue,
+                averageValue == null ? null : TimeFormatUtils.formatHourMinute(averageValue),
+                sampleSize
+            ),
+            dailyValues
+        );
+    }
+
+    private CountMetricSection buildTotalOutingCountSection(List<DailySlot> dailySlots) {
+        List<CountMetricSection.CountMetricDailyItem> dailyValues = new ArrayList<>();
+        long totalCount = 0L;
+        int sampleSize = 0;
+
+        for (DailySlot dailySlot : dailySlots) {
+            Integer count = dailySlot.dayRoute() == null ? null : dailySlot.dayRoute()
+                .getTotalOutingCount();
+            dailyValues.add(new CountMetricSection.CountMetricDailyItem(
+                dailySlot.date(),
+                dailySlot.dayRoute() != null,
+                count,
+                count == null ? null : count + "회"
+            ));
+
+            if (count != null) {
+                totalCount += count;
+                sampleSize++;
+            }
+        }
+
+        Double averageValue = sampleSize == 0 ? null
+            : Math.round(((double) totalCount / sampleSize) * 10.0) / 10.0;
+
+        return new CountMetricSection(
+            new CountMetricSection.CountMetricAverage(
+                averageValue,
+                averageValue == null ? null : formatCountText(averageValue),
+                sampleSize
+            ),
+            dailyValues
+        );
+    }
+
+    private DurationMetricSection buildTotalOutingSecondsSection(List<DailySlot> dailySlots) {
+        List<DurationMetricSection.DurationMetricDailyItem> dailyValues = new ArrayList<>();
+        long totalSeconds = 0L;
+        int sampleSize = 0;
+
+        for (DailySlot dailySlot : dailySlots) {
+            Long outingSeconds = dailySlot.dayRoute() == null ? null : dailySlot.dayRoute()
+                .getTotalOutingSeconds();
+            dailyValues.add(new DurationMetricSection.DurationMetricDailyItem(
+                dailySlot.date(),
+                dailySlot.dayRoute() != null,
+                outingSeconds,
+                outingSeconds == null ? null
+                    : DurationFormatUtils.formatOutingDurationText(outingSeconds)
+            ));
+
+            if (outingSeconds != null) {
+                totalSeconds += outingSeconds;
+                sampleSize++;
+            }
+        }
+
+        Long averageValue = sampleSize == 0 ? null : Math.round((double) totalSeconds / sampleSize);
+
+        return new DurationMetricSection(
+            new DurationMetricSection.DurationMetricAverage(
+                averageValue,
+                averageValue == null ? null
+                    : DurationFormatUtils.formatOutingDurationText(averageValue),
+                sampleSize
+            ),
+            dailyValues
+        );
+    }
+
+    private VisitedRegionsSection buildVisitedRegionsSection(List<DayRoute> dayRoutes) {
+        if (dayRoutes.isEmpty()) {
+            return new VisitedRegionsSection(List.of());
+        }
+
+        Map<String, RegionSummary> regionSummaryMap = new LinkedHashMap<>();
+        visitedRegionRepository.findByDayRouteInOrderByTotalStaySecondsDesc(dayRoutes)
+            .forEach(visitedRegion -> regionSummaryMap.computeIfAbsent(
+                    visitedRegion.getRegion().getDongName(),
+                    RegionSummary::new)
+                .add(visitedRegion));
+
+        List<RegionSummary> topRegions = regionSummaryMap.values().stream()
+            .sorted((left, right) -> Long.compare(right.totalStaySeconds(), left.totalStaySeconds()))
+            .limit(TOP_REGION_LIMIT)
+            .toList();
+
+        List<VisitedRegionsSection.VisitedRegionSummaryItem> items = new ArrayList<>();
+        for (int index = 0; index < topRegions.size(); index++) {
+            RegionSummary regionSummary = topRegions.get(index);
+            items.add(new VisitedRegionsSection.VisitedRegionSummaryItem(
+                index + 1,
+                regionSummary.regionName(),
+                regionSummary.totalStaySeconds(),
+                regionSummary.visitDays()
+            ));
+        }
+
+        return new VisitedRegionsSection(items);
+    }
+
+    private Integer getMinutesOfDay(DayRoute dayRoute, Function<DayRoute, Instant> extractor) {
+        if (dayRoute == null) {
+            return null;
+        }
+
+        Long minutesOfDay = TimeFormatUtils.toKstMinutesOfDay(extractor.apply(dayRoute));
+        return minutesOfDay == null ? null : minutesOfDay.intValue();
+    }
+
+    private String formatCountText(double value) {
+        if (value == Math.rint(value)) {
+            return ((long) value) + "회";
+        }
+        return value + "회";
+    }
+
+    private record DailySlot(LocalDate date, DayRoute dayRoute) {
+    }
+
+    private static final class RegionSummary {
+
+        private final String regionName;
+        private long totalStaySeconds;
+        private int visitDays;
+
+        private RegionSummary(String regionName) {
+            this.regionName = regionName;
+        }
+
+        private void add(VisitedRegion visitedRegion) {
+            totalStaySeconds += visitedRegion.getTotalStaySeconds();
+            visitDays++;
+        }
+
+        private String regionName() {
+            return regionName;
+        }
+
+        private long totalStaySeconds() {
+            return totalStaySeconds;
+        }
+
+        private int visitDays() {
+            return visitDays;
+        }
+    }
+}

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/service/WeeklyStatisticsService.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/service/WeeklyStatisticsService.java
@@ -114,8 +114,9 @@ public class WeeklyStatisticsService {
         int sampleSize = 0;
 
         for (DailySlot dailySlot : dailySlots) {
-            Integer count = dailySlot.dayRoute() == null ? null : dailySlot.dayRoute()
-                .getTotalOutingCount();
+            Integer count = hasOutingRecord(dailySlot.dayRoute())
+                ? dailySlot.dayRoute().getTotalOutingCount()
+                : null;
             dailyValues.add(new CountMetricSection.CountMetricDailyItem(
                 dailySlot.date(),
                 dailySlot.dayRoute() != null,
@@ -148,8 +149,9 @@ public class WeeklyStatisticsService {
         int sampleSize = 0;
 
         for (DailySlot dailySlot : dailySlots) {
-            Long outingSeconds = dailySlot.dayRoute() == null ? null : dailySlot.dayRoute()
-                .getTotalOutingSeconds();
+            Long outingSeconds = hasOutingRecord(dailySlot.dayRoute())
+                ? dailySlot.dayRoute().getTotalOutingSeconds()
+                : null;
             dailyValues.add(new DurationMetricSection.DurationMetricDailyItem(
                 dailySlot.date(),
                 dailySlot.dayRoute() != null,
@@ -215,6 +217,10 @@ public class WeeklyStatisticsService {
 
         Long minutesOfDay = TimeFormatUtils.toKstMinutesOfDay(extractor.apply(dayRoute));
         return minutesOfDay == null ? null : minutesOfDay.intValue();
+    }
+
+    private boolean hasOutingRecord(DayRoute dayRoute) {
+        return dayRoute != null && dayRoute.getOutingTime() != null;
     }
 
     private String formatCountText(double value) {

--- a/backend/src/main/java/backend/capstone/domain/mobility/statics/type/StatisticPeriod.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/statics/type/StatisticPeriod.java
@@ -1,0 +1,8 @@
+package backend.capstone.domain.mobility.statics.type;
+
+public enum StatisticPeriod {
+    WEEK,
+    MONTH,
+    SIX_MONTHS,
+    YEAR
+}

--- a/backend/src/main/java/backend/capstone/global/util/TimeFormatUtils.java
+++ b/backend/src/main/java/backend/capstone/global/util/TimeFormatUtils.java
@@ -1,0 +1,29 @@
+package backend.capstone.global.util;
+
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+//시간을 분 단위로 변환
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TimeFormatUtils {
+
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    public static Long toKstMinutesOfDay(Instant instant) {
+        if (instant == null) {
+            return null;
+        }
+
+        LocalTime localTime = instant.atZone(KST_ZONE_ID).toLocalTime();
+        return (long) (localTime.getHour() * 60 + localTime.getMinute());
+    }
+
+    public static String formatHourMinute(int totalMinutes) {
+        int hour = totalMinutes / 60;
+        int minute = totalMinutes % 60;
+        return String.format("%02d:%02d", hour, minute);
+    }
+}

--- a/backend/src/test/java/backend/capstone/domain/mobility/statics/service/StatisticMetricServiceTest.java
+++ b/backend/src/test/java/backend/capstone/domain/mobility/statics/service/StatisticMetricServiceTest.java
@@ -74,6 +74,44 @@ class StatisticMetricServiceTest {
     }
 
     @Test
+    void 일주일_귀가시각_상세_통계는_enterHomeTime_기준으로_계산한다() {
+        LocalDate today = LocalDate.of(2026, 5, 18);
+        User user = createUser();
+        DayRoute monday = createReturnedHomeDayRoute(user, LocalDate.of(2026, 5, 18),
+            Instant.parse("2026-05-18T14:15:00Z"));
+        DayRoute sunday = createReturnedHomeDayRoute(user, LocalDate.of(2026, 5, 17),
+            Instant.parse("2026-05-17T14:45:00Z"));
+
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 12), LocalDate.of(2026, 5, 18)))
+            .willReturn(List.of(sunday, monday));
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 5), LocalDate.of(2026, 5, 11)))
+            .willReturn(List.of(createReturnedHomeDayRoute(user, LocalDate.of(2026, 5, 11),
+                Instant.parse("2026-05-11T13:00:00Z"))));
+
+        var response = statisticMetricService.getEnterHomeTimeMetric(1L, StatisticPeriod.WEEK,
+            today);
+
+        assertThat(response.metricType()).isEqualTo("ENTER_HOME_TIME");
+        assertThat(response.period()).isEqualTo(StatisticPeriod.WEEK);
+        assertThat(response.average().value()).isEqualTo(1410);
+        assertThat(response.average().displayText()).isEqualTo("23:30");
+        assertThat(response.average().sampleSize()).isEqualTo(2);
+        assertThat(response.bars()).hasSize(7);
+        assertThat(response.bars().get(5).value()).isEqualTo(1425);
+        assertThat(response.bars().get(5).displayText()).isEqualTo("23:45");
+        assertThat(response.bars().get(6).value()).isEqualTo(1395);
+        assertThat(response.bars().get(6).displayText()).isEqualTo("23:15");
+        assertThat(response.highlight().title()).isEqualTo("이번 주 귀가");
+        assertThat(response.highlight().message()).isEqualTo("이번 주 평균 귀가 시각이 지난주보다 늦어졌어요.");
+        assertThat(response.highlight().current().label()).isEqualTo("이번 주");
+        assertThat(response.highlight().previous().label()).isEqualTo("지난주");
+        assertThat(response.highlight().previous().value()).isEqualTo(1320);
+        assertThat(response.highlight().previous().displayText()).isEqualTo("22:00");
+    }
+
+    @Test
     void 한달_외출시각_상세_통계는_일별_30개_막대를_반환한다() {
         LocalDate today = LocalDate.of(2026, 5, 18);
         given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
@@ -150,6 +188,15 @@ class StatisticMetricServiceTest {
             .date(date)
             .build();
         dayRoute.markOuting(outingTime);
+        return dayRoute;
+    }
+
+    private DayRoute createReturnedHomeDayRoute(User user, LocalDate date, Instant enterHomeTime) {
+        DayRoute dayRoute = DayRoute.builder()
+            .user(user)
+            .date(date)
+            .build();
+        dayRoute.markReturnedHome(enterHomeTime);
         return dayRoute;
     }
 }

--- a/backend/src/test/java/backend/capstone/domain/mobility/statics/service/StatisticMetricServiceTest.java
+++ b/backend/src/test/java/backend/capstone/domain/mobility/statics/service/StatisticMetricServiceTest.java
@@ -149,11 +149,10 @@ class StatisticMetricServiceTest {
     }
 
     @Test
-    void 총외출시간은_0초도_dayRoute가_있으면_평균에_포함한다() {
+    void 총외출시간은_외출기록이_없으면_평균에서_제외한다() {
         LocalDate today = LocalDate.of(2026, 5, 18);
         User user = createUser();
-        DayRoute monday = createTotalOutingSecondsDayRoute(user, LocalDate.of(2026, 5, 18),
-            0L);
+        DayRoute monday = createDayRouteWithoutOutingRecord(user, LocalDate.of(2026, 5, 18));
 
         given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
             LocalDate.of(2026, 5, 12), LocalDate.of(2026, 5, 18)))
@@ -165,12 +164,14 @@ class StatisticMetricServiceTest {
         var response = statisticMetricService.getTotalOutingSecondsMetric(1L,
             StatisticPeriod.WEEK, today);
 
-        assertThat(response.average().value()).isEqualTo(0);
-        assertThat(response.average().displayText()).isEqualTo("0분");
-        assertThat(response.average().sampleSize()).isEqualTo(1);
-        assertThat(response.bars().get(6).value()).isEqualTo(0);
-        assertThat(response.bars().get(6).hasValue()).isTrue();
-        assertThat(response.bars().get(6).sampleSize()).isEqualTo(1);
+        assertThat(response.average().value()).isNull();
+        assertThat(response.average().displayText()).isNull();
+        assertThat(response.average().sampleSize()).isZero();
+        assertThat(response.bars().get(6).value()).isNull();
+        assertThat(response.bars().get(6).displayText()).isNull();
+        assertThat(response.bars().get(6).hasValue()).isFalse();
+        assertThat(response.bars().get(6).sampleSize()).isZero();
+        assertThat(response.highlight().current().value()).isNull();
         assertThat(response.highlight().previous().value()).isNull();
         assertThat(response.highlight().message()).isEqualTo("이번 주 평균 외출시간을 지난주와 비교할 기록이 부족해요.");
     }
@@ -211,10 +212,10 @@ class StatisticMetricServiceTest {
     }
 
     @Test
-    void 외출횟수는_0회도_dayRoute가_있으면_평균에_포함한다() {
+    void 외출횟수는_외출기록이_없으면_평균에서_제외한다() {
         LocalDate today = LocalDate.of(2026, 5, 18);
         User user = createUser();
-        DayRoute monday = createTotalOutingCountDayRoute(user, LocalDate.of(2026, 5, 18), 0);
+        DayRoute monday = createDayRouteWithoutOutingRecord(user, LocalDate.of(2026, 5, 18));
 
         given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
             LocalDate.of(2026, 5, 12), LocalDate.of(2026, 5, 18)))
@@ -226,12 +227,14 @@ class StatisticMetricServiceTest {
         var response = statisticMetricService.getTotalOutingCountMetric(1L,
             StatisticPeriod.WEEK, today);
 
-        assertThat(response.average().value()).isEqualTo(0.0);
-        assertThat(response.average().displayText()).isEqualTo("0.0회");
-        assertThat(response.average().sampleSize()).isEqualTo(1);
-        assertThat(response.bars().get(6).value()).isEqualTo(0.0);
-        assertThat(response.bars().get(6).hasValue()).isTrue();
-        assertThat(response.bars().get(6).sampleSize()).isEqualTo(1);
+        assertThat(response.average().value()).isNull();
+        assertThat(response.average().displayText()).isNull();
+        assertThat(response.average().sampleSize()).isZero();
+        assertThat(response.bars().get(6).value()).isNull();
+        assertThat(response.bars().get(6).displayText()).isNull();
+        assertThat(response.bars().get(6).hasValue()).isFalse();
+        assertThat(response.bars().get(6).sampleSize()).isZero();
+        assertThat(response.highlight().current().value()).isNull();
         assertThat(response.highlight().previous().value()).isNull();
         assertThat(response.highlight().message()).isEqualTo("이번 주 평균 외출횟수를 지난주와 비교할 기록이 부족해요.");
     }
@@ -331,6 +334,7 @@ class StatisticMetricServiceTest {
             .user(user)
             .date(date)
             .build();
+        dayRoute.markOuting(Instant.parse("2026-05-18T00:00:00Z"));
         dayRoute.addOutingDurationSeconds(totalOutingSeconds);
         return dayRoute;
     }
@@ -345,5 +349,12 @@ class StatisticMetricServiceTest {
             dayRoute.markOuting(Instant.parse("2026-05-18T00:00:00Z"));
         }
         return dayRoute;
+    }
+
+    private DayRoute createDayRouteWithoutOutingRecord(User user, LocalDate date) {
+        return DayRoute.builder()
+            .user(user)
+            .date(date)
+            .build();
     }
 }

--- a/backend/src/test/java/backend/capstone/domain/mobility/statics/service/StatisticMetricServiceTest.java
+++ b/backend/src/test/java/backend/capstone/domain/mobility/statics/service/StatisticMetricServiceTest.java
@@ -112,6 +112,70 @@ class StatisticMetricServiceTest {
     }
 
     @Test
+    void 일주일_총외출시간_상세_통계는_totalOutingSeconds_기준으로_계산한다() {
+        LocalDate today = LocalDate.of(2026, 5, 18);
+        User user = createUser();
+        DayRoute monday = createTotalOutingSecondsDayRoute(user, LocalDate.of(2026, 5, 18),
+            7200L);
+        DayRoute sunday = createTotalOutingSecondsDayRoute(user, LocalDate.of(2026, 5, 17),
+            10800L);
+
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 12), LocalDate.of(2026, 5, 18)))
+            .willReturn(List.of(sunday, monday));
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 5), LocalDate.of(2026, 5, 11)))
+            .willReturn(List.of(createTotalOutingSecondsDayRoute(user, LocalDate.of(2026, 5, 11),
+                14400L)));
+
+        var response = statisticMetricService.getTotalOutingSecondsMetric(1L,
+            StatisticPeriod.WEEK, today);
+
+        assertThat(response.metricType()).isEqualTo("TOTAL_OUTING_SECONDS");
+        assertThat(response.period()).isEqualTo(StatisticPeriod.WEEK);
+        assertThat(response.average().value()).isEqualTo(9000);
+        assertThat(response.average().displayText()).isEqualTo("2시간 30분");
+        assertThat(response.average().sampleSize()).isEqualTo(2);
+        assertThat(response.bars()).hasSize(7);
+        assertThat(response.bars().get(5).value()).isEqualTo(10800);
+        assertThat(response.bars().get(5).displayText()).isEqualTo("3시간");
+        assertThat(response.bars().get(6).value()).isEqualTo(7200);
+        assertThat(response.bars().get(6).displayText()).isEqualTo("2시간");
+        assertThat(response.highlight().title()).isEqualTo("이번 주 외출시간");
+        assertThat(response.highlight().message()).isEqualTo("이번 주 평균 외출시간이 지난주보다 줄었어요.");
+        assertThat(response.highlight().current().value()).isEqualTo(9000);
+        assertThat(response.highlight().previous().value()).isEqualTo(14400);
+        assertThat(response.highlight().previous().displayText()).isEqualTo("4시간");
+    }
+
+    @Test
+    void 총외출시간은_0초도_dayRoute가_있으면_평균에_포함한다() {
+        LocalDate today = LocalDate.of(2026, 5, 18);
+        User user = createUser();
+        DayRoute monday = createTotalOutingSecondsDayRoute(user, LocalDate.of(2026, 5, 18),
+            0L);
+
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 12), LocalDate.of(2026, 5, 18)))
+            .willReturn(List.of(monday));
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 5), LocalDate.of(2026, 5, 11)))
+            .willReturn(List.of());
+
+        var response = statisticMetricService.getTotalOutingSecondsMetric(1L,
+            StatisticPeriod.WEEK, today);
+
+        assertThat(response.average().value()).isZero();
+        assertThat(response.average().displayText()).isEqualTo("0분");
+        assertThat(response.average().sampleSize()).isEqualTo(1);
+        assertThat(response.bars().get(6).value()).isZero();
+        assertThat(response.bars().get(6).hasValue()).isTrue();
+        assertThat(response.bars().get(6).sampleSize()).isEqualTo(1);
+        assertThat(response.highlight().previous().value()).isNull();
+        assertThat(response.highlight().message()).isEqualTo("이번 주 평균 외출시간을 지난주와 비교할 기록이 부족해요.");
+    }
+
+    @Test
     void 한달_외출시각_상세_통계는_일별_30개_막대를_반환한다() {
         LocalDate today = LocalDate.of(2026, 5, 18);
         given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
@@ -197,6 +261,16 @@ class StatisticMetricServiceTest {
             .date(date)
             .build();
         dayRoute.markReturnedHome(enterHomeTime);
+        return dayRoute;
+    }
+
+    private DayRoute createTotalOutingSecondsDayRoute(User user, LocalDate date,
+        long totalOutingSeconds) {
+        DayRoute dayRoute = DayRoute.builder()
+            .user(user)
+            .date(date)
+            .build();
+        dayRoute.addOutingDurationSeconds(totalOutingSeconds);
         return dayRoute;
     }
 }

--- a/backend/src/test/java/backend/capstone/domain/mobility/statics/service/StatisticMetricServiceTest.java
+++ b/backend/src/test/java/backend/capstone/domain/mobility/statics/service/StatisticMetricServiceTest.java
@@ -165,14 +165,75 @@ class StatisticMetricServiceTest {
         var response = statisticMetricService.getTotalOutingSecondsMetric(1L,
             StatisticPeriod.WEEK, today);
 
-        assertThat(response.average().value()).isZero();
+        assertThat(response.average().value()).isEqualTo(0);
         assertThat(response.average().displayText()).isEqualTo("0분");
         assertThat(response.average().sampleSize()).isEqualTo(1);
-        assertThat(response.bars().get(6).value()).isZero();
+        assertThat(response.bars().get(6).value()).isEqualTo(0);
         assertThat(response.bars().get(6).hasValue()).isTrue();
         assertThat(response.bars().get(6).sampleSize()).isEqualTo(1);
         assertThat(response.highlight().previous().value()).isNull();
         assertThat(response.highlight().message()).isEqualTo("이번 주 평균 외출시간을 지난주와 비교할 기록이 부족해요.");
+    }
+
+    @Test
+    void 일주일_외출횟수_상세_통계는_totalOutingCount_기준으로_계산한다() {
+        LocalDate today = LocalDate.of(2026, 5, 18);
+        User user = createUser();
+        DayRoute monday = createTotalOutingCountDayRoute(user, LocalDate.of(2026, 5, 18), 2);
+        DayRoute sunday = createTotalOutingCountDayRoute(user, LocalDate.of(2026, 5, 17), 4);
+
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 12), LocalDate.of(2026, 5, 18)))
+            .willReturn(List.of(sunday, monday));
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 5), LocalDate.of(2026, 5, 11)))
+            .willReturn(List.of(createTotalOutingCountDayRoute(user, LocalDate.of(2026, 5, 11),
+                5)));
+
+        var response = statisticMetricService.getTotalOutingCountMetric(1L,
+            StatisticPeriod.WEEK, today);
+
+        assertThat(response.metricType()).isEqualTo("TOTAL_OUTING_COUNT");
+        assertThat(response.period()).isEqualTo(StatisticPeriod.WEEK);
+        assertThat(response.average().value()).isEqualTo(3.0);
+        assertThat(response.average().displayText()).isEqualTo("3.0회");
+        assertThat(response.average().sampleSize()).isEqualTo(2);
+        assertThat(response.bars()).hasSize(7);
+        assertThat(response.bars().get(5).value()).isEqualTo(4.0);
+        assertThat(response.bars().get(5).displayText()).isEqualTo("4.0회");
+        assertThat(response.bars().get(6).value()).isEqualTo(2.0);
+        assertThat(response.bars().get(6).displayText()).isEqualTo("2.0회");
+        assertThat(response.highlight().title()).isEqualTo("이번 주 외출횟수");
+        assertThat(response.highlight().message()).isEqualTo("이번 주 평균 외출횟수가 지난주보다 줄었어요.");
+        assertThat(response.highlight().current().value()).isEqualTo(3.0);
+        assertThat(response.highlight().previous().value()).isEqualTo(5.0);
+        assertThat(response.highlight().previous().displayText()).isEqualTo("5.0회");
+    }
+
+    @Test
+    void 외출횟수는_0회도_dayRoute가_있으면_평균에_포함한다() {
+        LocalDate today = LocalDate.of(2026, 5, 18);
+        User user = createUser();
+        DayRoute monday = createTotalOutingCountDayRoute(user, LocalDate.of(2026, 5, 18), 0);
+
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 12), LocalDate.of(2026, 5, 18)))
+            .willReturn(List.of(monday));
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 5), LocalDate.of(2026, 5, 11)))
+            .willReturn(List.of());
+
+        var response = statisticMetricService.getTotalOutingCountMetric(1L,
+            StatisticPeriod.WEEK, today);
+
+        assertThat(response.average().value()).isEqualTo(0.0);
+        assertThat(response.average().displayText()).isEqualTo("0.0회");
+        assertThat(response.average().sampleSize()).isEqualTo(1);
+        assertThat(response.bars().get(6).value()).isEqualTo(0.0);
+        assertThat(response.bars().get(6).hasValue()).isTrue();
+        assertThat(response.bars().get(6).sampleSize()).isEqualTo(1);
+        assertThat(response.highlight().previous().value()).isNull();
+        assertThat(response.highlight().message()).isEqualTo("이번 주 평균 외출횟수를 지난주와 비교할 기록이 부족해요.");
     }
 
     @Test
@@ -271,6 +332,18 @@ class StatisticMetricServiceTest {
             .date(date)
             .build();
         dayRoute.addOutingDurationSeconds(totalOutingSeconds);
+        return dayRoute;
+    }
+
+    private DayRoute createTotalOutingCountDayRoute(User user, LocalDate date,
+        int totalOutingCount) {
+        DayRoute dayRoute = DayRoute.builder()
+            .user(user)
+            .date(date)
+            .build();
+        for (int count = 0; count < totalOutingCount; count++) {
+            dayRoute.markOuting(Instant.parse("2026-05-18T00:00:00Z"));
+        }
         return dayRoute;
     }
 }

--- a/backend/src/test/java/backend/capstone/domain/mobility/statics/service/StatisticMetricServiceTest.java
+++ b/backend/src/test/java/backend/capstone/domain/mobility/statics/service/StatisticMetricServiceTest.java
@@ -1,0 +1,155 @@
+package backend.capstone.domain.mobility.statics.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import backend.capstone.domain.mobility.dayroute.entity.DayRoute;
+import backend.capstone.domain.mobility.dayroute.repository.DayRouteRepository;
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import backend.capstone.domain.user.entity.ProviderType;
+import backend.capstone.domain.user.entity.User;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StatisticMetricServiceTest {
+
+    @InjectMocks
+    private StatisticMetricService statisticMetricService;
+
+    @Mock
+    private DayRouteRepository dayRouteRepository;
+
+    @Test
+    void 일주일_외출시각_상세_통계는_일별_7개_막대를_반환한다() {
+        LocalDate today = LocalDate.of(2026, 5, 18);
+        User user = createUser();
+        DayRoute monday = createDayRoute(user, LocalDate.of(2026, 5, 18),
+            Instant.parse("2026-05-18T00:12:00Z"));
+        DayRoute sunday = createDayRoute(user, LocalDate.of(2026, 5, 17),
+            Instant.parse("2026-05-17T00:42:00Z"));
+
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 12), LocalDate.of(2026, 5, 18)))
+            .willReturn(List.of(sunday, monday));
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 5), LocalDate.of(2026, 5, 11)))
+            .willReturn(List.of(createDayRoute(user, LocalDate.of(2026, 5, 11),
+                Instant.parse("2026-05-11T01:00:00Z"))));
+
+        var response = statisticMetricService.getOutingTimeMetric(1L, StatisticPeriod.WEEK, today);
+
+        assertThat(response.metricType()).isEqualTo("OUTING_TIME");
+        assertThat(response.period()).isEqualTo(StatisticPeriod.WEEK);
+        assertThat(response.startDate()).isEqualTo(LocalDate.of(2026, 5, 12));
+        assertThat(response.endDate()).isEqualTo(today);
+        assertThat(response.average().value()).isEqualTo(567);
+        assertThat(response.average().displayText()).isEqualTo("09:27");
+        assertThat(response.average().sampleSize()).isEqualTo(2);
+        assertThat(response.bars()).hasSize(7);
+        assertThat(response.bars()).extracting(bar -> bar.label())
+            .containsExactly("화", "수", "목", "금", "토", "일", "월");
+        assertThat(response.bars().get(5).value()).isEqualTo(582);
+        assertThat(response.bars().get(5).displayText()).isEqualTo("09:42");
+        assertThat(response.bars().get(6).value()).isEqualTo(552);
+        assertThat(response.bars().get(6).displayText()).isEqualTo("09:12");
+        assertThat(response.highlight()).isNotNull();
+        assertThat(response.highlight().title()).isEqualTo("이번 주 외출");
+        assertThat(response.highlight().message()).isEqualTo("이번 주 평균 외출 시간이 지난주보다 빨라졌어요.");
+        assertThat(response.highlight().current().label()).isEqualTo("이번 주");
+        assertThat(response.highlight().current().value()).isEqualTo(567);
+        assertThat(response.highlight().current().displayText()).isEqualTo("09:27");
+        assertThat(response.highlight().current().sampleSize()).isEqualTo(2);
+        assertThat(response.highlight().previous().label()).isEqualTo("지난주");
+        assertThat(response.highlight().previous().value()).isEqualTo(600);
+        assertThat(response.highlight().previous().displayText()).isEqualTo("10:00");
+        assertThat(response.highlight().previous().sampleSize()).isEqualTo(1);
+    }
+
+    @Test
+    void 한달_외출시각_상세_통계는_일별_30개_막대를_반환한다() {
+        LocalDate today = LocalDate.of(2026, 5, 18);
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 4, 19), today))
+            .willReturn(List.of());
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 3, 20), LocalDate.of(2026, 4, 18)))
+            .willReturn(List.of());
+
+        var response = statisticMetricService.getOutingTimeMetric(1L, StatisticPeriod.MONTH,
+            today);
+
+        assertThat(response.startDate()).isEqualTo(LocalDate.of(2026, 4, 19));
+        assertThat(response.bars()).hasSize(30);
+        assertThat(response.average().value()).isNull();
+        assertThat(response.average().displayText()).isNull();
+        assertThat(response.average().sampleSize()).isZero();
+        assertThat(response.highlight()).isNotNull();
+        assertThat(response.highlight().title()).isEqualTo("이번 달 외출");
+        assertThat(response.highlight().message()).isEqualTo("이번 달 평균 외출 시간을 지난달과 비교할 기록이 부족해요.");
+        assertThat(response.highlight().current().label()).isEqualTo("이번 달");
+        assertThat(response.highlight().previous().label()).isEqualTo("지난달");
+    }
+
+    @Test
+    void 육개월과_일년_외출시각_상세_통계는_월별_막대를_반환한다() {
+        LocalDate today = LocalDate.of(2026, 5, 18);
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2025, 12, 1), today))
+            .willReturn(List.of());
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2025, 6, 1), LocalDate.of(2025, 11, 30)))
+            .willReturn(List.of());
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2025, 6, 1), today))
+            .willReturn(List.of());
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2024, 6, 1), LocalDate.of(2025, 5, 31)))
+            .willReturn(List.of());
+
+        var sixMonthsResponse = statisticMetricService.getOutingTimeMetric(1L,
+            StatisticPeriod.SIX_MONTHS, today);
+        var yearResponse = statisticMetricService.getOutingTimeMetric(1L, StatisticPeriod.YEAR,
+            today);
+
+        assertThat(sixMonthsResponse.bars()).hasSize(6);
+        assertThat(sixMonthsResponse.startDate()).isEqualTo(LocalDate.of(2025, 12, 1));
+        assertThat(sixMonthsResponse.bars()).extracting(bar -> bar.label())
+            .containsExactly("12월", "1월", "2월", "3월", "4월", "5월");
+        assertThat(sixMonthsResponse.highlight()).isNotNull();
+        assertThat(sixMonthsResponse.highlight().title()).isEqualTo("최근 6개월 외출");
+        assertThat(sixMonthsResponse.highlight().current().label()).isEqualTo("최근 6개월");
+        assertThat(sixMonthsResponse.highlight().previous().label()).isEqualTo("이전 6개월");
+        assertThat(yearResponse.bars()).hasSize(12);
+        assertThat(yearResponse.startDate()).isEqualTo(LocalDate.of(2025, 6, 1));
+        assertThat(yearResponse.highlight()).isNotNull();
+        assertThat(yearResponse.highlight().title()).isEqualTo("최근 1년 외출");
+        assertThat(yearResponse.highlight().current().label()).isEqualTo("최근 1년");
+        assertThat(yearResponse.highlight().previous().label()).isEqualTo("이전 1년");
+    }
+
+    private User createUser() {
+        return User.builder()
+            .provider(ProviderType.KAKAO)
+            .providerId(UUID.randomUUID().toString())
+            .nickname("tester")
+            .profileImageUrl("https://example.com/profile.png")
+            .build();
+    }
+
+    private DayRoute createDayRoute(User user, LocalDate date, Instant outingTime) {
+        DayRoute dayRoute = DayRoute.builder()
+            .user(user)
+            .date(date)
+            .build();
+        dayRoute.markOuting(outingTime);
+        return dayRoute;
+    }
+}

--- a/backend/src/test/java/backend/capstone/domain/mobility/statics/service/VisitStatisticsServiceTest.java
+++ b/backend/src/test/java/backend/capstone/domain/mobility/statics/service/VisitStatisticsServiceTest.java
@@ -1,0 +1,114 @@
+package backend.capstone.domain.mobility.statics.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import backend.capstone.domain.mobility.analysis.visitedregion.entity.VisitedRegion;
+import backend.capstone.domain.mobility.analysis.visitedregion.repository.VisitedRegionRepository;
+import backend.capstone.domain.mobility.place.entity.Place;
+import backend.capstone.domain.mobility.place.entity.PlaceSource;
+import backend.capstone.domain.mobility.place.repository.PlaceRepository;
+import backend.capstone.domain.mobility.statics.type.StatisticPeriod;
+import backend.capstone.domain.region.entity.Region;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class VisitStatisticsServiceTest {
+
+    @InjectMocks
+    private VisitStatisticsService visitStatisticsService;
+
+    @Mock
+    private VisitedRegionRepository visitedRegionRepository;
+
+    @Mock
+    private PlaceRepository placeRepository;
+
+    @Test
+    void 방문통계는_방문동네_상위3개와_그외_그리고_장소_상위5개를_반환한다() {
+        LocalDate today = LocalDate.of(2026, 5, 18);
+        given(visitedRegionRepository.findByUserIdAndDateBetween(
+            1L, LocalDate.of(2026, 5, 12), today))
+            .willReturn(List.of(
+                createVisitedRegion("수유동"),
+                createVisitedRegion("수유동"),
+                createVisitedRegion("수유동"),
+                createVisitedRegion("정릉동"),
+                createVisitedRegion("정릉동"),
+                createVisitedRegion("성북동"),
+                createVisitedRegion("돈암동")
+            ));
+        given(placeRepository.findByUserIdAndDateBetween(1L, LocalDate.of(2026, 5, 12), today))
+            .willReturn(List.of(
+                createPlace("스타벅스 수유역점", "서울특별시 성북구 정릉로 77"),
+                createPlace("스타벅스 수유역점", "서울특별시 성북구 정릉로 77"),
+                createPlace("도서관", "서울특별시 성북구 보문로 1")
+            ));
+
+        var response = visitStatisticsService.getVisitStatistics(1L, StatisticPeriod.WEEK, today);
+
+        assertThat(response.period()).isEqualTo(StatisticPeriod.WEEK);
+        assertThat(response.startDate()).isEqualTo(LocalDate.of(2026, 5, 12));
+        assertThat(response.endDate()).isEqualTo(today);
+        assertThat(response.visitedRegions().totalVisitCount()).isEqualTo(7);
+        assertThat(response.visitedRegions().items()).hasSize(4);
+        assertThat(response.visitedRegions().items().get(0).regionName()).isEqualTo("수유동");
+        assertThat(response.visitedRegions().items().get(0).visitCount()).isEqualTo(3);
+        assertThat(response.visitedRegions().items().get(0).ratio()).isEqualTo(42.9);
+        assertThat(response.visitedRegions().items().get(0).displayRatio()).isEqualTo("43%");
+        assertThat(response.visitedRegions().items().get(3).regionName()).isEqualTo("그 외");
+        assertThat(response.visitedRegions().items().get(3).visitCount()).isEqualTo(1);
+        assertThat(response.places().totalVisitCount()).isEqualTo(3);
+        assertThat(response.places().items()).hasSize(2);
+        assertThat(response.places().items().get(0).placeName()).isEqualTo("스타벅스 수유역점");
+        assertThat(response.places().items().get(0).visitCount()).isEqualTo(2);
+        assertThat(response.places().items().get(0).displayVisitCount()).isEqualTo("2회");
+    }
+
+    @Test
+    void 방문통계는_방문기록이_없으면_빈목록을_반환한다() {
+        LocalDate today = LocalDate.of(2026, 5, 18);
+        given(visitedRegionRepository.findByUserIdAndDateBetween(
+            1L, LocalDate.of(2026, 4, 19), today))
+            .willReturn(List.of());
+        given(placeRepository.findByUserIdAndDateBetween(1L, LocalDate.of(2026, 4, 19), today))
+            .willReturn(List.of());
+
+        var response = visitStatisticsService.getVisitStatistics(1L, StatisticPeriod.MONTH, today);
+
+        assertThat(response.startDate()).isEqualTo(LocalDate.of(2026, 4, 19));
+        assertThat(response.visitedRegions().totalVisitCount()).isZero();
+        assertThat(response.visitedRegions().items()).isEmpty();
+        assertThat(response.places().totalVisitCount()).isZero();
+        assertThat(response.places().items()).isEmpty();
+    }
+
+    private VisitedRegion createVisitedRegion(String dongName) {
+        return VisitedRegion.builder()
+            .region(Region.builder()
+                .legalDongCode(dongName)
+                .sidoName("서울특별시")
+                .sigunguName("성북구")
+                .dongName(dongName)
+                .build())
+            .totalStaySeconds(600L)
+            .build();
+    }
+
+    private Place createPlace(String name, String roadAddress) {
+        return Place.builder()
+            .name(name)
+            .roadAddress(roadAddress)
+            .latitude(37.0)
+            .longitude(127.0)
+            .orderIndex(1)
+            .source(PlaceSource.AUTO)
+            .build();
+    }
+}

--- a/backend/src/test/java/backend/capstone/domain/mobility/statics/service/WeeklyStatisticsServiceTest.java
+++ b/backend/src/test/java/backend/capstone/domain/mobility/statics/service/WeeklyStatisticsServiceTest.java
@@ -62,8 +62,12 @@ class WeeklyStatisticsServiceTest {
         assertThat(response.endDate()).isEqualTo(LocalDate.of(2026, 5, 13));
         assertThat(response.outingTime().average().displayText()).isEqualTo("09:15");
         assertThat(response.enterHomeTime().average().displayText()).isEqualTo("23:15");
-        assertThat(response.totalOutingCount().average().displayText()).isEqualTo("1회");
-        assertThat(response.totalOutingSeconds().average().displayText()).isEqualTo("3시간 40분");
+        assertThat(response.totalOutingCount().average().displayText()).isEqualTo("1.5회");
+        assertThat(response.totalOutingSeconds().average().displayText()).isEqualTo("5시간 30분");
+        assertThat(response.totalOutingCount().sevenDays().get(6).value()).isNull();
+        assertThat(response.totalOutingCount().sevenDays().get(6).displayText()).isNull();
+        assertThat(response.totalOutingSeconds().sevenDays().get(6).value()).isNull();
+        assertThat(response.totalOutingSeconds().sevenDays().get(6).displayText()).isNull();
         assertThat(response.visitedRegions().topRegions()).hasSize(2);
         assertThat(response.visitedRegions().topRegions().get(0).regionName()).isEqualTo("성북구");
     }

--- a/backend/src/test/java/backend/capstone/domain/mobility/statics/service/WeeklyStatisticsServiceTest.java
+++ b/backend/src/test/java/backend/capstone/domain/mobility/statics/service/WeeklyStatisticsServiceTest.java
@@ -1,0 +1,105 @@
+package backend.capstone.domain.mobility.statics.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import backend.capstone.domain.mobility.analysis.visitedregion.entity.VisitedRegion;
+import backend.capstone.domain.mobility.analysis.visitedregion.repository.VisitedRegionRepository;
+import backend.capstone.domain.mobility.dayroute.entity.DayRoute;
+import backend.capstone.domain.mobility.dayroute.repository.DayRouteRepository;
+import backend.capstone.domain.region.entity.Region;
+import backend.capstone.domain.user.entity.ProviderType;
+import backend.capstone.domain.user.entity.User;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WeeklyStatisticsServiceTest {
+
+    @Mock
+    private DayRouteRepository dayRouteRepository;
+
+    @Mock
+    private VisitedRegionRepository visitedRegionRepository;
+
+    @Test
+    void 최근_7일_통계를_집계한다() {
+        WeeklyStatisticsService weeklyStatisticsService = new WeeklyStatisticsService(
+            dayRouteRepository, visitedRegionRepository);
+        User user = createUser();
+        DayRoute first = createDayRoute(user, LocalDate.of(2026, 5, 7),
+            Instant.parse("2026-05-07T00:00:00Z"), Instant.parse("2026-05-07T14:00:00Z"), 1,
+            18_000);
+        DayRoute second = createDayRoute(user, LocalDate.of(2026, 5, 9),
+            Instant.parse("2026-05-09T00:30:00Z"), Instant.parse("2026-05-09T14:30:00Z"), 2,
+            21_600);
+        DayRoute third = createDayRoute(user, LocalDate.of(2026, 5, 13), null, null, 0, 0);
+
+        given(dayRouteRepository.findByUserIdAndDateBetweenOrderByDate(1L,
+            LocalDate.of(2026, 5, 7), LocalDate.of(2026, 5, 13)))
+            .willReturn(List.of(first, second, third));
+        given(visitedRegionRepository.findByDayRouteInOrderByTotalStaySecondsDesc(List.of(first,
+            second, third)))
+            .willReturn(List.of(
+                VisitedRegion.builder().dayRoute(first).region(createRegion("성북구"))
+                    .totalStaySeconds(7200).build(),
+                VisitedRegion.builder().dayRoute(second).region(createRegion("성북구"))
+                    .totalStaySeconds(3600).build(),
+                VisitedRegion.builder().dayRoute(second).region(createRegion("강북구"))
+                    .totalStaySeconds(1800).build()
+            ));
+
+        var response = weeklyStatisticsService.getWeeklyStatistics(1L,
+            LocalDate.of(2026, 5, 13));
+
+        assertThat(response.startDate()).isEqualTo(LocalDate.of(2026, 5, 7));
+        assertThat(response.endDate()).isEqualTo(LocalDate.of(2026, 5, 13));
+        assertThat(response.outingTime().average().displayText()).isEqualTo("09:15");
+        assertThat(response.enterHomeTime().average().displayText()).isEqualTo("23:15");
+        assertThat(response.totalOutingCount().average().displayText()).isEqualTo("1회");
+        assertThat(response.totalOutingSeconds().average().displayText()).isEqualTo("3시간 40분");
+        assertThat(response.visitedRegions().topRegions()).hasSize(2);
+        assertThat(response.visitedRegions().topRegions().get(0).regionName()).isEqualTo("성북구");
+    }
+
+    private User createUser() {
+        return User.builder()
+            .provider(ProviderType.KAKAO)
+            .providerId(UUID.randomUUID().toString())
+            .nickname("tester")
+            .profileImageUrl("https://example.com/profile.png")
+            .build();
+    }
+
+    private DayRoute createDayRoute(User user, LocalDate date, Instant outingTime,
+        Instant enterHomeTime, int totalOutingCount, long totalOutingSeconds) {
+        DayRoute dayRoute = DayRoute.builder()
+            .user(user)
+            .date(date)
+            .build();
+        if (outingTime != null) {
+            dayRoute.markOuting(outingTime);
+            for (int count = 1; count < totalOutingCount; count++) {
+                dayRoute.markReturnedHome(enterHomeTime == null ? outingTime : enterHomeTime);
+                dayRoute.markOuting(outingTime.plusSeconds(count));
+            }
+        }
+        if (enterHomeTime != null) {
+            dayRoute.markReturnedHome(enterHomeTime);
+        }
+        dayRoute.addOutingDurationSeconds(totalOutingSeconds);
+        return dayRoute;
+    }
+
+    private Region createRegion(String dongName) {
+        return Region.builder()
+            .dongName(dongName)
+            .build();
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#38 

## 🪐 작업 내용
### api 변동 사항
#### 개인사용자 전용
<img width="732" height="573" alt="image" src="https://github.com/user-attachments/assets/8dbced78-a892-4cf8-adb5-4fdd71459937" />

- 최근 7일 주간 요약 조회 API 추가
- 외출시각 상세 통계 조회 API 추가
- 귀가시각 상세 통계 조회 API 추가
- 총 외출시간 상세 통계 조회 API 추가
- 외출횟수 상세 통계 조회 API 추가
- 방문 동네 및 장소 통계 조회 API 추가

#### 보호대상자 전용
<img width="796" height="602" alt="image" src="https://github.com/user-attachments/assets/1e606291-6c87-45f7-ac40-37235d17bdae" />

추가된 api와 응답 형식 개인 사용자 api와 모두 동일

## 📚 추가 리팩토링 가능성
