### PR TITLE
fix #47: 외출, 귀가 판별시 3분 유지 조건 제거

### DIFF
--- a/backend/src/main/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/entity/OngoingHomeStatus.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/entity/OngoingHomeStatus.java
@@ -44,11 +44,6 @@ public class OngoingHomeStatus extends BaseTimeEntity {
     @Column(nullable = false)
     private HomeZoneStatus currentZoneStatus;
 
-    @Enumerated(EnumType.STRING)
-    private HomeZoneStatus candidateZoneStatus;
-
-    private Instant candidateStartedAt;
-
     private Instant lastTransitionAt;
 
     public static OngoingHomeStatus initialize(DayRoute dayRoute, GpsPoint point,
@@ -61,19 +56,8 @@ public class OngoingHomeStatus extends BaseTimeEntity {
         return status;
     }
 
-    public void startCandidate(HomeZoneStatus candidateZoneStatus, Instant candidateStartedAt) {
-        this.candidateZoneStatus = candidateZoneStatus;
-        this.candidateStartedAt = candidateStartedAt;
-    }
-
-    public void clearCandidate() {
-        this.candidateZoneStatus = null;
-        this.candidateStartedAt = null;
-    }
-
     public void changeCurrentZoneStatus(HomeZoneStatus currentZoneStatus, Instant transitionedAt) {
         this.currentZoneStatus = currentZoneStatus;
         this.lastTransitionAt = transitionedAt;
-        clearCandidate();
     }
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/HomeStatusAnalysisService.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/HomeStatusAnalysisService.java
@@ -94,13 +94,13 @@ public class HomeStatusAnalysisService {
         HomeZoneStatus observedZoneStatus = homeZoneDecider.determineObservedZone(point,
             homeBookmark, ongoingHomeStatus.getCurrentZoneStatus());
 
-        long additionalOutingSeconds = outingDurationAccumulator.calculateSegmentOutingDurationSeconds(
-            ongoingHomeStatus, observedZoneStatus, previousPointAt, point.getRecordedAt());
+        long outingSeconds = outingDurationAccumulator.calculateOutingDurationSeconds(
+            ongoingHomeStatus.getCurrentZoneStatus(), previousPointAt, point.getRecordedAt());
 
-        additionalOutingSeconds += homeStatusTransitionHandler.handleTransition(dayRoute,
-            ongoingHomeStatus, observedZoneStatus, point.getRecordedAt());
+        homeStatusTransitionHandler.handleTransition(dayRoute, ongoingHomeStatus,
+            observedZoneStatus, point.getRecordedAt());
 
-        return additionalOutingSeconds;
+        return outingSeconds;
     }
 
 }

--- a/backend/src/main/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/HomeStatusTransitionHandler.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/HomeStatusTransitionHandler.java
@@ -3,18 +3,11 @@ package backend.capstone.domain.mobility.analysis.ongoinghomestatus.service;
 import backend.capstone.domain.mobility.analysis.ongoinghomestatus.entity.HomeZoneStatus;
 import backend.capstone.domain.mobility.analysis.ongoinghomestatus.entity.OngoingHomeStatus;
 import backend.capstone.domain.mobility.dayroute.entity.DayRoute;
-import java.time.Duration;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class HomeStatusTransitionHandler {
-
-    private static final int TRANSITION_MINUTES = 3;
-
-    private final OutingDurationAccumulator outingDurationAccumulator;
 
     public void applyInitialDayRouteStatus(DayRoute dayRoute, HomeZoneStatus zoneStatus) {
         if (zoneStatus == HomeZoneStatus.IN_HOME) {
@@ -25,32 +18,14 @@ public class HomeStatusTransitionHandler {
         dayRoute.markOutingWithoutTime();
     }
 
-    public long handleTransition(DayRoute dayRoute, OngoingHomeStatus ongoingHomeStatus,
+    public void handleTransition(DayRoute dayRoute, OngoingHomeStatus ongoingHomeStatus,
         HomeZoneStatus observedZoneStatus, Instant observedAt) {
         if (observedZoneStatus == ongoingHomeStatus.getCurrentZoneStatus()) {
-            ongoingHomeStatus.clearCandidate();
-            return 0;
+            return;
         }
 
-        if ((ongoingHomeStatus.getCandidateZoneStatus() == null)
-            || (ongoingHomeStatus.getCandidateZoneStatus() != observedZoneStatus)) {
-            ongoingHomeStatus.startCandidate(observedZoneStatus, observedAt);
-            return 0;
-        }
-
-        long candidateDurationMinutes = Duration.between(ongoingHomeStatus.getCandidateStartedAt(),
-            observedAt).toMinutes();
-
-        if (candidateDurationMinutes < TRANSITION_MINUTES) {
-            return 0;
-        }
-
-        Instant transitionTime = ongoingHomeStatus.getCandidateStartedAt();
-        ongoingHomeStatus.changeCurrentZoneStatus(observedZoneStatus, transitionTime);
-        applyTransitionedDayRouteStatus(dayRoute, observedZoneStatus, transitionTime);
-
-        return outingDurationAccumulator.calculateConfirmedOutingDurationSeconds(observedZoneStatus,
-            transitionTime, observedAt);
+        ongoingHomeStatus.changeCurrentZoneStatus(observedZoneStatus, observedAt);
+        applyTransitionedDayRouteStatus(dayRoute, observedZoneStatus, observedAt);
     }
 
     private void applyTransitionedDayRouteStatus(DayRoute dayRoute, HomeZoneStatus zoneStatus,

--- a/backend/src/main/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/OutingDurationAccumulator.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/OutingDurationAccumulator.java
@@ -1,7 +1,6 @@
 package backend.capstone.domain.mobility.analysis.ongoinghomestatus.service;
 
 import backend.capstone.domain.mobility.analysis.ongoinghomestatus.entity.HomeZoneStatus;
-import backend.capstone.domain.mobility.analysis.ongoinghomestatus.entity.OngoingHomeStatus;
 import java.time.Duration;
 import java.time.Instant;
 import org.springframework.stereotype.Component;
@@ -9,31 +8,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class OutingDurationAccumulator {
 
-    public long calculateSegmentOutingDurationSeconds(OngoingHomeStatus ongoingHomeStatus,
-        HomeZoneStatus observedZoneStatus, Instant previousPointAt, Instant currentPointAt) {
-        if (previousPointAt == null
-            || ongoingHomeStatus.getCurrentZoneStatus() != HomeZoneStatus.OUT_HOME) {
-            return 0;
-        }
-
-        if (ongoingHomeStatus.getCandidateZoneStatus() == HomeZoneStatus.IN_HOME) {
-            if (observedZoneStatus == HomeZoneStatus.OUT_HOME) {
-                return Duration.between(ongoingHomeStatus.getCandidateStartedAt(), currentPointAt)
-                    .getSeconds();
-            }
+    public long calculateOutingDurationSeconds(HomeZoneStatus currentZoneStatus,
+        Instant previousPointAt, Instant currentPointAt) {
+        if (previousPointAt == null || currentZoneStatus != HomeZoneStatus.OUT_HOME) {
             return 0;
         }
 
         return Duration.between(previousPointAt, currentPointAt).getSeconds();
-    }
-
-    //외출 확정됐을 때 외출 candidate 시간 누적
-    public long calculateConfirmedOutingDurationSeconds(HomeZoneStatus transitionedZoneStatus,
-        Instant transitionTime, Instant currentPointAt) {
-        if (transitionedZoneStatus != HomeZoneStatus.OUT_HOME) {
-            return 0;
-        }
-
-        return Duration.between(transitionTime, currentPointAt).getSeconds();
     }
 }

--- a/backend/src/test/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/HomeStatusAnalysisServiceTest.java
+++ b/backend/src/test/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/HomeStatusAnalysisServiceTest.java
@@ -91,7 +91,6 @@ class HomeStatusAnalysisServiceTest {
         assertThat(savedDayRoute.getEnterHomeTime()).isNull();
         assertThat(savedDayRoute.getHomeAnalysisLastPointAt()).isEqualTo(firstPointAt);
         assertThat(ongoingHomeStatus.getCurrentZoneStatus()).isEqualTo(HomeZoneStatus.IN_HOME);
-        assertThat(ongoingHomeStatus.getCandidateZoneStatus()).isNull();
     }
 
     @Test
@@ -116,17 +115,15 @@ class HomeStatusAnalysisServiceTest {
     }
 
     @Test
-    void 집_안에서_시작한_후_집_밖_상태가_3분_이상_유지되면_OUTING으로_확정된다() {
+    void 집_밖_상태가_관측되면_다음_포인트_없이_즉시_OUTING으로_확정된다() {
         User user = saveUser();
         DayRoute dayRoute = saveDayRoute(user, LocalDate.of(2026, 5, 1));
         saveHomeBookmark(user);
 
         Instant startAt = Instant.parse("2026-05-01T00:00:00Z");
-        Instant candidateStartAt = Instant.parse("2026-05-01T00:03:00Z");
-        Instant transitionObservedAt = Instant.parse("2026-05-01T00:06:00Z");
+        Instant transitionObservedAt = Instant.parse("2026-05-01T00:03:00Z");
 
         insertGpsPoint(dayRoute, INSIDE_HOME_LATITUDE, INSIDE_HOME_LONGITUDE, startAt);
-        insertGpsPoint(dayRoute, OUTSIDE_HOME_LATITUDE, OUTSIDE_HOME_LONGITUDE, candidateStartAt);
         insertGpsPoint(dayRoute, OUTSIDE_HOME_LATITUDE, OUTSIDE_HOME_LONGITUDE,
             transitionObservedAt);
 
@@ -138,24 +135,24 @@ class HomeStatusAnalysisServiceTest {
             .orElseThrow();
 
         assertThat(savedDayRoute.getDayRouteHomeStatus()).isEqualTo(DayRouteHomeStatus.OUTING);
-        assertThat(savedDayRoute.getOutingTime()).isEqualTo(candidateStartAt);
+        assertThat(savedDayRoute.getOutingTime()).isEqualTo(transitionObservedAt);
         assertThat(savedDayRoute.getHomeAnalysisLastPointAt()).isEqualTo(transitionObservedAt);
         assertThat(ongoingHomeStatus.getCurrentZoneStatus()).isEqualTo(HomeZoneStatus.OUT_HOME);
-        assertThat(ongoingHomeStatus.getCandidateZoneStatus()).isNull();
     }
 
     @Test
-    void 집_밖_candidate가_생겼다가_다시_집_안이면_외출로_확정되지_않는다() {
+    void 집_밖으로_나갔다가_바로_돌아오면_외출과_귀가가_각각_즉시_확정된다() {
         User user = saveUser();
         DayRoute dayRoute = saveDayRoute(user, LocalDate.of(2026, 5, 1));
         saveHomeBookmark(user);
 
+        Instant outingAt = Instant.parse("2026-05-01T00:03:00Z");
+        Instant returnedAt = Instant.parse("2026-05-01T00:04:00Z");
+
         insertGpsPoint(dayRoute, INSIDE_HOME_LATITUDE, INSIDE_HOME_LONGITUDE,
             Instant.parse("2026-05-01T00:00:00Z"));
-        insertGpsPoint(dayRoute, OUTSIDE_HOME_LATITUDE, OUTSIDE_HOME_LONGITUDE,
-            Instant.parse("2026-05-01T00:03:00Z"));
-        insertGpsPoint(dayRoute, INSIDE_HOME_LATITUDE, INSIDE_HOME_LONGITUDE,
-            Instant.parse("2026-05-01T00:04:00Z"));
+        insertGpsPoint(dayRoute, OUTSIDE_HOME_LATITUDE, OUTSIDE_HOME_LONGITUDE, outingAt);
+        insertGpsPoint(dayRoute, INSIDE_HOME_LATITUDE, INSIDE_HOME_LONGITUDE, returnedAt);
 
         homeStatusAnalysisService.analyzeHomeStatus(dayRoute.getId());
 
@@ -164,11 +161,11 @@ class HomeStatusAnalysisServiceTest {
                 savedDayRoute)
             .orElseThrow();
 
-        assertThat(savedDayRoute.getDayRouteHomeStatus()).isEqualTo(DayRouteHomeStatus.AT_HOME);
-        assertThat(savedDayRoute.getOutingTime()).isNull();
+        assertThat(savedDayRoute.getDayRouteHomeStatus()).isEqualTo(DayRouteHomeStatus.RETURNED_HOME);
+        assertThat(savedDayRoute.getOutingTime()).isEqualTo(outingAt);
+        assertThat(savedDayRoute.getEnterHomeTime()).isEqualTo(returnedAt);
+        assertThat(savedDayRoute.getTotalOutingCount()).isEqualTo(1);
         assertThat(ongoingHomeStatus.getCurrentZoneStatus()).isEqualTo(HomeZoneStatus.IN_HOME);
-        assertThat(ongoingHomeStatus.getCandidateZoneStatus()).isNull();
-        assertThat(ongoingHomeStatus.getCandidateStartedAt()).isNull();
     }
 
     private User saveUser() {

--- a/backend/src/test/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/HomeStatusTransitionHandlerTest.java
+++ b/backend/src/test/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/HomeStatusTransitionHandlerTest.java
@@ -1,0 +1,90 @@
+package backend.capstone.domain.mobility.analysis.ongoinghomestatus.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import backend.capstone.domain.mobility.analysis.ongoinghomestatus.entity.HomeZoneStatus;
+import backend.capstone.domain.mobility.analysis.ongoinghomestatus.entity.OngoingHomeStatus;
+import backend.capstone.domain.mobility.dayroute.entity.DayRoute;
+import backend.capstone.domain.mobility.dayroute.entity.DayRouteHomeStatus;
+import backend.capstone.domain.mobility.gpspoint.entity.GpsPoint;
+import java.lang.reflect.Constructor;
+import java.time.Instant;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class HomeStatusTransitionHandlerTest {
+
+    private HomeStatusTransitionHandler homeStatusTransitionHandler;
+
+    @BeforeEach
+    void setUp() {
+        homeStatusTransitionHandler = new HomeStatusTransitionHandler();
+    }
+
+    @Test
+    void 관측_상태가_현재_상태와_같으면_아무것도_변하지_않는다() throws Exception {
+        DayRoute dayRoute = createDayRoute();
+        OngoingHomeStatus ongoingHomeStatus = createOngoingHomeStatus(HomeZoneStatus.OUT_HOME,
+            Instant.parse("2026-05-01T00:00:00Z"));
+
+        homeStatusTransitionHandler.handleTransition(dayRoute, ongoingHomeStatus,
+            HomeZoneStatus.OUT_HOME, Instant.parse("2026-05-01T00:05:00Z"));
+
+        assertThat(ongoingHomeStatus.getCurrentZoneStatus()).isEqualTo(HomeZoneStatus.OUT_HOME);
+        assertThat(dayRoute.getEnterHomeTime()).isNull();
+        assertThat(dayRoute.getOutingTime()).isNull();
+    }
+
+    @Test
+    void 관측_상태가_다르면_다음_포인트_없이_즉시_귀가로_확정된다() throws Exception {
+        DayRoute dayRoute = createDayRoute();
+        OngoingHomeStatus ongoingHomeStatus = createOngoingHomeStatus(HomeZoneStatus.OUT_HOME,
+            Instant.parse("2026-05-01T00:00:00Z"));
+        Instant observedAt = Instant.parse("2026-05-01T00:05:00Z");
+
+        homeStatusTransitionHandler.handleTransition(dayRoute, ongoingHomeStatus,
+            HomeZoneStatus.IN_HOME, observedAt);
+
+        assertThat(dayRoute.getDayRouteHomeStatus()).isEqualTo(DayRouteHomeStatus.RETURNED_HOME);
+        assertThat(dayRoute.getEnterHomeTime()).isEqualTo(observedAt);
+        assertThat(ongoingHomeStatus.getCurrentZoneStatus()).isEqualTo(HomeZoneStatus.IN_HOME);
+    }
+
+    @Test
+    void 관측_상태가_다르면_다음_포인트_없이_즉시_외출로_확정된다() throws Exception {
+        DayRoute dayRoute = createDayRoute();
+        OngoingHomeStatus ongoingHomeStatus = createOngoingHomeStatus(HomeZoneStatus.IN_HOME,
+            Instant.parse("2026-05-01T00:00:00Z"));
+        Instant observedAt = Instant.parse("2026-05-01T00:05:00Z");
+
+        homeStatusTransitionHandler.handleTransition(dayRoute, ongoingHomeStatus,
+            HomeZoneStatus.OUT_HOME, observedAt);
+
+        assertThat(dayRoute.getDayRouteHomeStatus()).isEqualTo(DayRouteHomeStatus.OUTING);
+        assertThat(dayRoute.getOutingTime()).isEqualTo(observedAt);
+        assertThat(ongoingHomeStatus.getCurrentZoneStatus()).isEqualTo(HomeZoneStatus.OUT_HOME);
+    }
+
+    private DayRoute createDayRoute() {
+        return DayRoute.builder()
+            .date(LocalDate.of(2026, 5, 1))
+            .build();
+    }
+
+    private OngoingHomeStatus createOngoingHomeStatus(HomeZoneStatus currentZoneStatus,
+        Instant recordedAt) throws Exception {
+        DayRoute dayRoute = createDayRoute();
+        GpsPoint gpsPoint = createGpsPoint(recordedAt);
+        return OngoingHomeStatus.initialize(dayRoute, gpsPoint, currentZoneStatus);
+    }
+
+    private GpsPoint createGpsPoint(Instant recordedAt) throws Exception {
+        Constructor<GpsPoint> constructor = GpsPoint.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        GpsPoint gpsPoint = constructor.newInstance();
+        ReflectionTestUtils.setField(gpsPoint, "recordedAt", recordedAt);
+        return gpsPoint;
+    }
+}

--- a/backend/src/test/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/OutingDurationAccumulatorTest.java
+++ b/backend/src/test/java/backend/capstone/domain/mobility/analysis/ongoinghomestatus/service/OutingDurationAccumulatorTest.java
@@ -3,16 +3,9 @@ package backend.capstone.domain.mobility.analysis.ongoinghomestatus.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import backend.capstone.domain.mobility.analysis.ongoinghomestatus.entity.HomeZoneStatus;
-import backend.capstone.domain.mobility.analysis.ongoinghomestatus.entity.OngoingHomeStatus;
-import backend.capstone.domain.mobility.analysis.ongoinghomestatus.service.OutingDurationAccumulator;
-import backend.capstone.domain.mobility.dayroute.entity.DayRoute;
-import backend.capstone.domain.mobility.gpspoint.entity.GpsPoint;
-import java.lang.reflect.Constructor;
 import java.time.Instant;
-import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 class OutingDurationAccumulatorTest {
 
@@ -24,101 +17,28 @@ class OutingDurationAccumulatorTest {
     }
 
     @Test
-    void previousPointAt이_null이면_외출시간을_누적하지_않는다() throws Exception {
-        OngoingHomeStatus ongoingHomeStatus = createOngoingHomeStatus(HomeZoneStatus.OUT_HOME,
-            Instant.parse("2026-05-01T00:00:00Z"));
+    void previousPointAt이_null이면_외출시간을_누적하지_않는다() {
+        long outingSeconds = outingDurationAccumulator.calculateOutingDurationSeconds(
+            HomeZoneStatus.OUT_HOME, null, Instant.parse("2026-05-01T00:03:00Z"));
 
-        long outingSeconds = outingDurationAccumulator.calculateSegmentOutingDurationSeconds(
-            ongoingHomeStatus, HomeZoneStatus.OUT_HOME, null,
+        assertThat(outingSeconds).isZero();
+    }
+
+    @Test
+    void 현재_확정상태가_OUT_HOME이_아니면_외출시간을_누적하지_않는다() {
+        long outingSeconds = outingDurationAccumulator.calculateOutingDurationSeconds(
+            HomeZoneStatus.IN_HOME, Instant.parse("2026-05-01T00:00:00Z"),
             Instant.parse("2026-05-01T00:03:00Z"));
 
         assertThat(outingSeconds).isZero();
     }
 
     @Test
-    void 현재_확정상태가_OUT_HOME이_아니면_외출시간을_누적하지_않는다() throws Exception {
-        OngoingHomeStatus ongoingHomeStatus = createOngoingHomeStatus(HomeZoneStatus.IN_HOME,
-            Instant.parse("2026-05-01T00:00:00Z"));
-
-        long outingSeconds = outingDurationAccumulator.calculateSegmentOutingDurationSeconds(
-            ongoingHomeStatus, HomeZoneStatus.IN_HOME, Instant.parse("2026-05-01T00:00:00Z"),
-            Instant.parse("2026-05-01T00:03:00Z"));
-
-        assertThat(outingSeconds).isZero();
-    }
-
-    @Test
-    void 현재_확정상태가_OUT_HOME이고_candidate가_없으면_직전_구간을_누적한다() throws Exception {
-        OngoingHomeStatus ongoingHomeStatus = createOngoingHomeStatus(HomeZoneStatus.OUT_HOME,
-            Instant.parse("2026-05-01T00:00:00Z"));
-
-        long outingSeconds = outingDurationAccumulator.calculateSegmentOutingDurationSeconds(
-            ongoingHomeStatus, HomeZoneStatus.OUT_HOME, Instant.parse("2026-05-01T00:00:00Z"),
+    void 현재_확정상태가_OUT_HOME이면_직전_포인트부터_이번_포인트까지를_누적한다() {
+        long outingSeconds = outingDurationAccumulator.calculateOutingDurationSeconds(
+            HomeZoneStatus.OUT_HOME, Instant.parse("2026-05-01T00:00:00Z"),
             Instant.parse("2026-05-01T00:03:00Z"));
 
         assertThat(outingSeconds).isEqualTo(180);
-    }
-
-    @Test
-    void 귀가_candidate가_생기고_이번_관측도_귀가방향이면_구간을_누적하지_않는다() throws Exception {
-        OngoingHomeStatus ongoingHomeStatus = createOngoingHomeStatus(HomeZoneStatus.OUT_HOME,
-            Instant.parse("2026-05-01T00:00:00Z"));
-        ongoingHomeStatus.startCandidate(HomeZoneStatus.IN_HOME,
-            Instant.parse("2026-05-01T00:03:00Z"));
-
-        long outingSeconds = outingDurationAccumulator.calculateSegmentOutingDurationSeconds(
-            ongoingHomeStatus, HomeZoneStatus.IN_HOME, Instant.parse("2026-05-01T00:03:00Z"),
-            Instant.parse("2026-05-01T00:06:00Z"));
-
-        assertThat(outingSeconds).isZero();
-    }
-
-    @Test
-    void 귀가_candidate가_취소되고_다시_OUT_HOME이_관측되면_candidate_시작시점부터_복구누적한다() throws Exception {
-        OngoingHomeStatus ongoingHomeStatus = createOngoingHomeStatus(HomeZoneStatus.OUT_HOME,
-            Instant.parse("2026-05-01T00:00:00Z"));
-        ongoingHomeStatus.startCandidate(HomeZoneStatus.IN_HOME,
-            Instant.parse("2026-05-01T00:03:00Z"));
-
-        long outingSeconds = outingDurationAccumulator.calculateSegmentOutingDurationSeconds(
-            ongoingHomeStatus, HomeZoneStatus.OUT_HOME, Instant.parse("2026-05-01T00:03:00Z"),
-            Instant.parse("2026-05-01T00:06:00Z"));
-
-        assertThat(outingSeconds).isEqualTo(180);
-    }
-
-    @Test
-    void 외출전이가_확정되면_candidate_시작시점부터_현재시점까지를_보정누적한다() {
-        long outingSeconds = outingDurationAccumulator.calculateConfirmedOutingDurationSeconds(
-            HomeZoneStatus.OUT_HOME, Instant.parse("2026-05-01T00:03:00Z"),
-            Instant.parse("2026-05-01T00:06:00Z"));
-
-        assertThat(outingSeconds).isEqualTo(180);
-    }
-
-    @Test
-    void 귀가전이가_확정되면_보정누적하지_않는다() {
-        long outingSeconds = outingDurationAccumulator.calculateConfirmedOutingDurationSeconds(
-            HomeZoneStatus.IN_HOME, Instant.parse("2026-05-01T00:03:00Z"),
-            Instant.parse("2026-05-01T00:06:00Z"));
-
-        assertThat(outingSeconds).isZero();
-    }
-
-    private OngoingHomeStatus createOngoingHomeStatus(HomeZoneStatus currentZoneStatus,
-        Instant recordedAt) throws Exception {
-        DayRoute dayRoute = DayRoute.builder()
-            .date(LocalDate.of(2026, 5, 1))
-            .build();
-        GpsPoint gpsPoint = createGpsPoint(recordedAt);
-        return OngoingHomeStatus.initialize(dayRoute, gpsPoint, currentZoneStatus);
-    }
-
-    private GpsPoint createGpsPoint(Instant recordedAt) throws Exception {
-        Constructor<GpsPoint> constructor = GpsPoint.class.getDeclaredConstructor();
-        constructor.setAccessible(true);
-        GpsPoint gpsPoint = constructor.newInstance();
-        ReflectionTestUtils.setField(gpsPoint, "recordedAt", recordedAt);
-        return gpsPoint;
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number

closes #47

## 🪐 작업 내용

- `HomeStatusTransitionHandler`에서 홈존(80m 진입/120m 이탈 히스테리시스) 판정이 바뀌어도
  다음 GPS 포인트로 3분간 재확인해야 확정하던 candidate 대기 로직을 제거하고, 관측 즉시
  외출/귀가를 확정하도록 변경했습니다.

- 안드로이드 클라이언트(`LocationPersistencePolicy`)는 이전 저장 위치 대비 35m 이상
  이동하지 않으면 좌표 자체를 저장·전송하지 않습니다. 기존 3분 대기 로직은 이 정책과
  맞물려, 사용자가 집에 도착해 정지하면 확정을 재확인해줄 다음 포인트가 오지 않아
  `day_route.enter_home_time`이 영구히 NULL로 남는 구조적 문제가 있었습니다.

- 히스테리시스(80m/120m)와 클라이언트의 정확도 필터(≤35m)가 이미 노이즈를 걸러주므로,
  별도 대기 없이 즉시 확정해도 안전하다고 판단했습니다.

- `OngoingHomeStatus`의 candidate 관련 필드(`candidateZoneStatus`, `candidateStartedAt`)와
  `startCandidate()`/`clearCandidate()` 메서드를 제거해 엔티티를 단순화했습니다.

- 관련 단위 테스트(`HomeStatusTransitionHandlerTest`, `OutingDurationAccumulatorTest`,
  `HomeStatusAnalysisServiceTest`)를 즉시 확정 시나리오에 맞게 갱신·추가했습니다. 그중
  "집 밖으로 나갔다가 바로 돌아오면 외출 1회로 카운트된다"는 트레이드오프도 테스트로
  명문화했습니다.

## 📚 추가 리팩토링 가능성

- DB 스키마에 `candidate_zone_status`/`candidate_started_at` 컬럼이 남아있다면(마이그레이션
  도구 사용 여부 미확인) 별도 정리가 필요할 수 있습니다.
- 로컬 `@SpringBootTest` 실행에 `JWT_SECRET`/`REDIS_HOST`/`REDIS_PORT`/`KAKAO_REST_API_KEY`
  환경변수가 필요한데 README에 최소 목록이 명시되어 있지 않아, 신규 기여자 온보딩 시
  documentation을 보강하면 좋을 것 같습니다.