### PR TITLE
feat : nginx 리버스 프록시 + Let's Encrypt로 HTTPS 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,6 +89,18 @@ jobs:
           strip_components: 1
           overwrite: true
 
+      # EC2로 nginx 설정 업로드 (디렉터리째 업로드 — conf 파일이 늘어도 이 스텝은 안 바뀜)
+      - name: Upload nginx conf to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "backend/nginx"
+          target: "/home/${{ secrets.EC2_USER }}/app"
+          strip_components: 1
+          overwrite: true
+
       # EC2에서 최신 이미지 pull + 재기동
       - name: Deploy on EC2
         uses: appleboy/ssh-action@v1.0.3

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,26 @@
+# 새 워크트리 생성 시 자동으로 함께 복사할 gitignore된 파일들 (Claude Code EnterWorktree 전용).
+# gitignore 문법을 쓰며, 여기 매칭되면서 동시에 실제로 gitignore된 파일만 복사 대상이 된다
+# (git이 추적 중인 파일은 애초에 워크트리 생성 시 정상적으로 함께 체크아웃되므로 여기 적을
+# 필요가 없다).
+#
+# 빌드 캐시/산출물(.gradle, build/, node_modules/, .terraform/ 등)은 각 워크트리에서 빌드
+# 도구가 알아서 재생성하므로 일부러 제외했다 — 용량만 크고 복사할 이유가 없다.
+
+# ── backend ──────────────────────────────────────────────────
+# 로컬 개발 환경변수 (backend/.claude/CLAUDE.md의 하이브리드 로컬 실행에 필요)
+backend/.env.local
+# Firebase 서비스 계정 키 (docker-compose.prod.yml 바인드 마운트 대상, 로컬 실행에도 필요)
+backend/gilbut-firebase-adminsdk.json
+# RDS 접속 런북의 실제 값 (rds-access.md가 참조하는 rds-access.local.md 등)
+backend/.claude/rules/*.local.md
+# Terraform 변수 파일 (backend/infra/prod, backend/infra/bootstrap 등 — 실제 계정 ID/비밀번호)
+backend/infra/**/*.tfvars
+# 계정 이관 작업용 로컬 시크릿(EC2 SSH 프라이빗 키 등)
+backend/.secrets/
+
+# ── android ───────────────────────────────────────────────────
+# SDK 경로 + 시크릿(kakao.nativeAppKey, app.baseUrl, google.mapsApiKey)
+android/local.properties
+# 릴리스 서명 키 (있는 경우)
+android/**/*.jks
+android/**/*.keystore

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -3,8 +3,11 @@ services:
     # 이미지 주소는 APP_IMAGE 환경변수로 분리. 미설정 시 아래 기본값으로 폴백(하위 호환).
     image: ${APP_IMAGE}
     container_name: myapp
-    ports:
-      - "80:8080"
+    # nginx가 80/443을 대신 받아 8080으로 프록시하므로 호스트 포트를 직접 물지 않는다
+    # (compose 기본 네트워크에서 서비스명 app:8080으로 컨테이너 간 통신은 expose 없이도 가능하나,
+    # 의도 문서화 목적으로 명시).
+    expose:
+      - "8080"
     depends_on:
       - redis
     env_file:
@@ -16,11 +19,15 @@ services:
     # 컨테이너 메모리 천장(cgroup). "피크×1.3~1.5배" 마진 규칙은 이 인스턴스에서 물리 메모리
     # 자체를 넘어서(피크 실측 최대 728.5MiB 기준 947~1093MiB 필요, t3.micro 가용은 913MiB뿐)
     # 성립하지 않아, 대신 호스트가 절대 메모리 부족에 빠지지 않도록 물리 예산을 엄격히 나눠
-    # 역산했다: 913(가용) - 230(OS+dockerd) - 40(redis mem_limit) = 643 → 640m.
-    # 힙 상한은 기본 ergonomics로 160MB(=640m의 25%). 앱의 진짜 수요(swap-free 추정
-    # ~700~730MiB)보다 작게 잡은 값이라, 초과분은 swap이 상시적으로 흡수하는 걸 전제로 한다.
-    # 산출 과정: docs/tech/infra/EC2 응답 불능 문제 해결하기.md
-    mem_limit: 640m
+    # 역산했다: 913(가용) - 230(OS+dockerd) - 40(redis) - 20(nginx) - 30(certbot) = 613 → 590m
+    # (HTTPS 적용으로 nginx/certbot 컨테이너가 추가되며 640m에서 재조정됨. nginx/certbot 값은
+    # 실측 전 추정치이므로 배포 후 docker stats로 재조정 필요).
+    # 힙 상한은 기본 ergonomics로 mem_limit의 25%. 앱의 진짜 수요(swap-free 추정 ~700~730MiB)보다
+    # 작게 잡은 값이라, 초과분은 swap이 상시적으로 흡수하는 걸 전제로 한다(캡이 줄어든 만큼
+    # swap 의존도가 기존보다 늘어남).
+    # 산출 과정: docs/tech/infra/EC2 응답 불능 문제 해결하기.md,
+    # docs/tech/infra/nginx-certbot로 HTTPS 적용하기.md
+    mem_limit: 590m
     restart: always
 
   redis:
@@ -37,5 +44,42 @@ services:
     mem_limit: 40m
     restart: always
 
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - app
+    # conf.d는 배포 시 레포(backend/nginx/conf.d)에서 그대로 올라온다. 인증서 발급 전(Phase A)엔
+    # 80만 쓰는 conf, 발급 후(Phase C)엔 443 TLS 종료가 추가된 conf로 교체된다 — 산출 근거·순서는
+    # docs/tech/infra/nginx-certbot로 HTTPS 적용하기.md 참고.
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+      - certbot-etc:/etc/letsencrypt:ro
+      - certbot-www:/var/www/certbot:ro
+    mem_limit: 20m
+    restart: always
+
+  certbot:
+    image: certbot/certbot:latest
+    container_name: certbot
+    volumes:
+      - certbot-etc:/etc/letsencrypt
+      - certbot-www:/var/www/certbot
+    # webroot 방식 자동 갱신 루프(공식 권장 패턴). 최초 발급은 이 루프가 아니라 수동 1회
+    # `docker compose run --rm certbot certonly ...`로 한다(문서 참고) — 인증서가 없으면
+    # renew는 아무 것도 하지 않으므로 최초 배포 시점부터 떠 있어도 무해하다.
+    entrypoint: >
+      /bin/sh -c "trap exit TERM; while :; do
+      certbot renew --webroot -w /var/www/certbot --quiet;
+      sleep 12h & wait $${!};
+      done"
+    mem_limit: 30m
+    restart: always
+
 volumes:
   redis-data:
+  certbot-etc:
+  certbot-www:

--- a/backend/docs/tech/infra/nginx-certbot로 HTTPS 적용하기.md
+++ b/backend/docs/tech/infra/nginx-certbot로 HTTPS 적용하기.md
@@ -1,0 +1,143 @@
+# nginx + certbot으로 HTTPS 적용하기
+
+## 배경
+
+`passedpath.site` 도메인을 Route53에 위임한 다음 단계로 HTTPS를 적용했다. ALB + ACM 대신
+**nginx 리버스 프록시 + Let's Encrypt(certbot)** 를 선택했다 — 이 프로젝트는 EC2 t3.micro
+단일 인스턴스라 ALB의 핵심 가치(여러 대상으로 트래픽 분산)를 쓸 수가 없고, ALB는 트래픽
+유무와 무관하게 월 $16~20 이상 상시 과금되는 반면 Let's Encrypt 인증서는 무료다. 보안그룹은
+이미 443이 열려 있어(`infra/prod/network.tf`의 `ec2_public_https`) Terraform 변경 없이
+`docker-compose.prod.yml`과 애플리케이션 레이어만으로 끝나는 작업이다.
+
+## 메모리 예산 재계산
+
+기존 예산(`EC2 응답 불능 문제 해결하기.md` 참고): t3.micro 가용 913MiB 중
+`913 − 230(OS+dockerd) − 40(redis) = 643 → app 640m`, 여유 3MiB.
+
+nginx(단일 백엔드 프록시, 캡스톤 규모 트래픽)와 certbot(하루 대부분 `sleep 12h`로 유휴,
+갱신 체크 시에만 python 프로세스가 잠깐 뜸)은 가볍지만 스파이크 여유를 감안해 각각
+20m/30m으로 잡고, 그만큼을 app에서 뗀다.
+
+| 구성 요소 | mem_limit | 비고 |
+|---|---|---|
+| OS + dockerd | 230 MiB | 고정, 기존과 동일 |
+| redis | 40m | 기존 유지 |
+| nginx | 20m | 신규, **실측 전 추정치** |
+| certbot | 30m | 신규, 갱신 시 python 프로세스 스파이크 대비 |
+| app | 640m → **590m** | 역산: 913−230−40−20−30−3(여유) |
+
+**트레이드오프**: app 실측 피크(728.5MiB)는 이미 640m 캡을 넘어 swap으로 흡수하는 걸
+전제로 설계돼 있었다. 590m으로 더 줄이면 swap 의존분이 88.5MiB → 138.5MiB로 늘어난다.
+PR #62에서 마련한 2GB swap 안전망 안에서는 감당 가능한 범위지만, 배포 후 `docker stats`나
+CloudWatch로 app 컨테이너 재기동(`restart:always`) 빈도가 기존보다 눈에 띄게 잦아지지
+않는지 확인이 필요하다. 더 줄여야 하는 상황이 오면 nginx/certbot 캡을 더 깎기보다
+t3.small 승급을 검토해야 한다(이미 최소치에 가깝다).
+
+## 최초 인증서 발급 절차
+
+인증서가 없는 상태에서 443 `server` 블록(`ssl_certificate` 참조)이 있는 nginx 설정을
+배포하면 **nginx가 그 파일을 찾지 못해 컨테이너 기동 자체가 실패한다.** 그래서 배포를
+두 단계로 나눈다.
+
+### Phase A — 80만 쓰는 설정으로 우선 배포
+
+`backend/nginx/conf.d/app.conf`에 이미 반영되어 있다: 80번 포트로 acme-challenge를
+서빙하고 나머지는 곧바로 app으로 프록시(리다이렉트 없음, HTTP로 계속 서비스). 이 상태를
+`release-server`에 배포하면 nginx가 정상 기동하고 앱은 HTTP로 계속 응답한다.
+
+### 인증서 발급 (EC2에 SSH로 1회 수동 실행)
+
+```bash
+cd /home/<EC2_USER>/app
+
+# 1) webroot 경로가 실제로 동작하는지 Let's Encrypt staging 환경으로 검증.
+#    --dry-run은 디스크에 아무 인증서도 남기지 않으므로 이후 실제 발급과 충돌하지 않는다.
+docker compose -f docker-compose.prod.yml run --rm certbot certonly \
+  --webroot -w /var/www/certbot -d passedpath.site \
+  --email jeeun03@gmail.com --agree-tos --no-eff-email --dry-run
+
+# 2) 검증 통과 후 실제 발급 (rate limit: 도메인당 주 5회, 아래 "알려진 함정" 참고)
+docker compose -f docker-compose.prod.yml run --rm certbot certonly \
+  --webroot -w /var/www/certbot -d passedpath.site \
+  --email jeeun03@gmail.com --agree-tos --no-eff-email
+
+# 3) 발급 확인
+docker exec nginx ls /etc/letsencrypt/live/passedpath.site/
+# fullchain.pem, privkey.pem 등이 보이면 성공
+```
+
+### Phase C — 443 포함 최종 설정으로 교체
+
+인증서 발급이 끝나면 `backend/nginx/conf.d/app.conf`를 아래 내용으로 교체하고
+커밋·배포한다 (인증서는 `certbot-etc` named volume에 이미 영속화되어 있으므로 nginx가
+443 블록으로 기동해도 문제없다):
+
+```nginx
+server {
+    listen 80;
+    server_name passedpath.site;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name passedpath.site;
+
+    ssl_certificate     /etc/letsencrypt/live/passedpath.site/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/passedpath.site/privkey.pem;
+
+    location / {
+        proxy_pass http://app:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+배포 후 `https://passedpath.site`가 정상 응답하고 `http://passedpath.site`가 301로
+리다이렉트되는지 확인한다.
+
+## 자동 갱신과 nginx reload
+
+`docker-compose.prod.yml`의 `certbot` 서비스는 공식 권장 패턴(`while : do certbot renew;
+sleep 12h; done`)으로 상시 떠서 만료가 가까운 인증서를 자동 갱신한다. 다만 **nginx는
+파일이 바뀌어도 reload 없이는 새 인증서를 읽지 않는다.** `docker.sock`을 certbot
+컨테이너에 마운트해 `--deploy-hook`으로 직접 reload시키는 방법도 있지만, 사실상 호스트
+root 권한을 컨테이너에 넘겨주는 셈이라 이 프로젝트 규모에는 과하다.
+
+이 저장소는 이미 PR #62의 swap 설정처럼 "1회성 수동 작업 + 런북 문서화" 관례를 쓰고
+있으므로, 동일하게 EC2 호스트 crontab에 1회 등록한다(코드화하지 않음):
+
+```bash
+# EC2 호스트에서 1회 실행
+crontab -e
+# 추가: 매일 03:00 reload. 인증서가 그날 갱신됐든 아니든 reload 자체는 무중단이라 안전하다.
+0 3 * * * docker exec nginx nginx -s reload >> /var/log/nginx-reload.log 2>&1
+```
+
+## 알려진 함정
+
+- **인증서 없이 443 블록 배포 금지**: `ssl_certificate`가 가리키는 파일이 없으면 nginx
+  컨테이너가 기동 자체에 실패한다. 반드시 Phase A(80만) → 발급 → Phase C(443 포함) 순서를
+  지킨다.
+- **Let's Encrypt rate limit**: 동일 도메인 기준 주 5회로 제한된다. 발급 전 항상
+  `--dry-run`으로 먼저 검증한다.
+- **nginx/certbot mem_limit(20m/30m)은 실측 전 추정치**다. 배포 후 `docker stats`로 실제
+  RSS를 확인해 필요하면 재조정한다.
+
+## 향후 개선 여지
+
+- crontab 기반 reload를 systemd timer나 `inotifywait` 기반 이벤트 트리거로 바꾸면 더
+  정교해지지만, 현재 규모(수동 부트스트랩 + 런북 문서화 관례)에는 과하다고 판단해 보류.
+- HSTS, `ssl_protocols`/`ssl_ciphers` 최신 권장값 등 TLS 설정 강화는 이번 1차 적용 범위
+  밖으로 남겨뒀다.
+- t3.small로 승급하는 시점이 오면 이 문서의 메모리 예산 표를 다시 산정해야 한다.

--- a/backend/nginx/conf.d/app.conf
+++ b/backend/nginx/conf.d/app.conf
@@ -1,0 +1,25 @@
+# Phase A: 인증서 발급 전 임시 설정 — 80만 사용.
+#
+# 인증서(certbot-etc 볼륨)가 아직 없는 상태에서 443 server 블록(ssl_certificate 참조)이 있는
+# conf를 배포하면 nginx가 그 파일을 찾지 못해 기동 자체에 실패한다. 그래서 최초 배포는 80만
+# 있는 이 설정으로 하고, 이 상태에서 certbot으로 인증서를 발급받은 뒤 443 TLS 종료 + 80→443
+# 리다이렉트가 포함된 최종본으로 교체한다(별도 커밋). 순서와 명령어는
+# docs/tech/infra/nginx-certbot로 HTTPS 적용하기.md 참고.
+server {
+    listen 80;
+    server_name passedpath.site;
+
+    # Let's Encrypt HTTP-01 challenge. 최초 발급뿐 아니라 갱신 때마다 매번 이 경로로 검증하므로
+    # Phase C(443 적용) 이후에도 계속 남겨둬야 한다.
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        proxy_pass http://app:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number

(관련 이슈 없음 — 인프라 개선 작업)

## 🪐 작업 내용

### 배경

`passedpath.site` 도메인을 Route53에 연결한 다음 단계로 HTTPS를 적용했다. ALB+ACM 대신
nginx 리버스 프록시 + Let's Encrypt(certbot)를 선택했다 — 단일 EC2 t3.micro 인스턴스라
ALB의 로드밸런싱 가치를 못 쓰는 반면, ALB는 상시 과금되고 Let's Encrypt는 무료이기 때문이다.

### 1. HTTPS 리버스 프록시 체계 (nginx + certbot)

- **nginx가 80/443을 받아 TLS를 종료하고 내부적으로 app 컨테이너(8080)로 프록시**하는
  구조를 `docker-compose.prod.yml`에 구성했다. app은 더 이상 호스트 포트를 직접 물지
  않는다.
- certbot을 webroot 방식으로 붙여 Let's Encrypt 인증서 발급·자동 갱신 체계를 마련했다.
  최초 발급은 인증서 없이 443 블록을 배포하면 nginx가 기동 실패하는 문제 때문에, 80
  전용 설정(1차 배포) → 발급 → 443 포함 최종 설정(2차 배포) 순서로 나눴다.
- **t3.micro 913MiB 메모리 예산 안에서 nginx(20m)·certbot(30m) 몫을 새로 배분하고, app의
  `mem_limit`을 640m→590m으로 재조정**했다. 산출 과정과 트레이드오프(앱의 swap 의존도
  증가)는 `backend/docs/tech/infra/nginx-certbot로 HTTPS 적용하기.md` 참고.
- 배포 파이프라인(`deploy.yml`)에 nginx 설정을 EC2로 올리는 scp 스텝을 추가했다.
- 최초 발급 절차, 인증서 갱신 후 nginx reload를 위한 EC2 crontab 등록법, 알려진 함정 (rate limit 등)은 신규 런북 문서에 정리했다.

### 2. 워크트리 작업 편의 개선

- 여러 Claude Code 세션을 워크트리로 병렬 운용할 때, gitignore된 로컬 설정(Terraform tfvars, `.env.local`, Firebase 서비스 계정 키, RDS 접속 로컬 값, 안드로이드  `local.properties`/서명 키 등)이 새 워크트리에 자동으로 복사되지 않는 문제가 있어  `.worktreeinclude`를 추가했다.

## 📚 추가 리팩토링 가능성

- nginx/certbot의 `mem_limit`(20m/30m)은 실측 전 추정치라 배포 후 `docker stats`로 재조정이 필요할 수 있다.
- HSTS, `ssl_protocols`/`ssl_ciphers` 최신 권장값 등 TLS 설정 강화는 이번 범위 밖으로
  남겨뒀다.
- 인증서 갱신 후 nginx reload를 EC2 crontab(수동 등록)으로 처리하는데, systemd
  timer나 `inotifywait` 기반 이벤트 트리거로 바꾸면 더 정교해진다.
