### PR TITLE
feat : nginx HTTPS 최종 설정 적용

### DIFF
--- a/backend/nginx/conf.d/app.conf
+++ b/backend/nginx/conf.d/app.conf
@@ -1,19 +1,26 @@
-# Phase A: 인증서 발급 전 임시 설정 — 80만 사용.
+# Phase C: 인증서 발급 완료 후 최종 설정 — 443 TLS 종료 + 80→443 리다이렉트.
 #
-# 인증서(certbot-etc 볼륨)가 아직 없는 상태에서 443 server 블록(ssl_certificate 참조)이 있는
-# conf를 배포하면 nginx가 그 파일을 찾지 못해 기동 자체에 실패한다. 그래서 최초 배포는 80만
-# 있는 이 설정으로 하고, 이 상태에서 certbot으로 인증서를 발급받은 뒤 443 TLS 종료 + 80→443
-# 리다이렉트가 포함된 최종본으로 교체한다(별도 커밋). 순서와 명령어는
-# docs/tech/infra/nginx-certbot로 HTTPS 적용하기.md 참고.
+# 발급 절차와 Phase A→C 전환 순서는 docs/tech/infra/nginx-certbot로 HTTPS 적용하기.md 참고.
 server {
     listen 80;
     server_name passedpath.site;
 
-    # Let's Encrypt HTTP-01 challenge. 최초 발급뿐 아니라 갱신 때마다 매번 이 경로로 검증하므로
-    # Phase C(443 적용) 이후에도 계속 남겨둬야 한다.
+    # Let's Encrypt HTTP-01 challenge. 갱신 때마다 매번 이 경로로 검증하므로 계속 남겨둔다.
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
     }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name passedpath.site;
+
+    ssl_certificate     /etc/letsencrypt/live/passedpath.site/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/passedpath.site/privkey.pem;
 
     location / {
         proxy_pass http://app:8080;


### PR DESCRIPTION
## 🛰️ Issue Number

(#65의 후속 — HTTPS 적용 2단계)

## 🪐 작업 내용

### 배경

#65에서 nginx를 80 전용으로 먼저 배포한 뒤, EC2에서 Let's Encrypt 인증서
발급을 완료했다(passedpath.site, 2026-10-19 만료). 이 PR은 
443 TLS 종료 + 80→443 리다이렉트가 포함된 최종 nginx 설정으로 전환한다.

### nginx 설정 전환

- 80: acme-challenge 경로는 유지(갱신 시에도 필요), 나머지는 443으로 301 리다이렉트
- 443: `/etc/letsencrypt/live/passedpath.site/{fullchain,privkey}.pem`으로 TLS
  종료 후 app:8080으로 프록시

## 📚 추가 리팩토링 가능성

- 인증서 자동 갱신 후 nginx reload를 위한 EC2 crontab 등록은 이 PR과 별개로 배포
  직후 수동 진행 예정 (`docs/tech/infra/nginx-certbot로 HTTPS 적용하기.md` 참고)