### PR TITLE
feat : 배포 환경 JVM 메모리 지표 CloudWatch 관측 도입

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,8 @@ jobs:
           KAKAO_REST_API_KEY=${{ secrets.KAKAO_REST_API_KEY }}
           DDL_AUTO=${{ secrets.DDL_AUTO }}
           FIREBASE_CREDENTIALS_PATH=${{ secrets.FIREBASE_CREDENTIALS_PATH }}
+          AWS_REGION=ap-northeast-2
+          CLOUDWATCH_METRICS_ENABLED=true
           EOF
 
       # EC2로 .env 업로드

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,3 +22,8 @@ REDIS_PORT=6380
 KAKAO_REST_API_KEY=
 FIREBASE_CREDENTIALS_PATH=
 DDL_AUTO=
+
+# --- JVM 메모리 지표 CloudWatch 관측 (배포 환경 전용) ---
+# 로컬은 IAM 자격증명이 없어 export가 계속 실패하므로 false 유지. 운영 .env에서만 true로 켠다.
+AWS_REGION=ap-northeast-2
+CLOUDWATCH_METRICS_ENABLED=false

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-cloudwatch2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/backend/src/main/java/backend/capstone/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/backend/capstone/auth/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                     "/swagger-ui/**",
                     "/swagger-ui.html",
                     "/v3/api-docs/**", "/webjars/**", "/swagger-resources/**", "/favicon.ico",
-                    "/error")
+                    "/error", "/actuator/health")
                 .permitAll()
                 .anyRequest().authenticated()
             )

--- a/backend/src/main/java/backend/capstone/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/backend/capstone/auth/filter/JwtAuthenticationFilter.java
@@ -79,7 +79,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             || uri.startsWith("/api/auth")
             || uri.startsWith("/oauth2")
             || uri.startsWith("/login")
-            || uri.equals("/favicon.ico");
+            || uri.equals("/favicon.ico")
+            || uri.startsWith("/actuator/health");
     }
 
     private String resolveBearerToken(HttpServletRequest request) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -29,6 +29,29 @@ logging:
 server:
   forward-headers-strategy: framework
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never
+  metrics:
+    enable:
+      all: false
+      jvm:
+        memory: true
+        gc: true
+        threads: true
+  cloudwatch:
+    metrics:
+      export:
+        enabled: ${CLOUDWATCH_METRICS_ENABLED:false}
+        namespace: Gilbut/App
+        step: 1m
+        batch-size: 20
+
 kakao:
   auth:
     base-url: https://kapi.kakao.com


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용

### 배경

로컬 GC 로그·cgroup 폴링 실험(`backend/docs/tech/infra/oom-repro-evidence/local/2026-07-17-부팅버스트-실험요약.md`)으로 부팅 버스트 힙 피크(231MiB)를 실측했지만, 배포 환경(EC2)에서 상시로 관측할 방법이 없었다. Prometheus+Grafana 자체 호스팅은 t3.micro 메모리 예산(913MiB 중 이미 680MiB가 컨테이너 mem_limit로 소진)상 관측 도구 자체가 OOM을 재현시킬 위험이 커, CloudWatch push 방식을 선택했다.

### 1. JVM 메모리 지표 CloudWatch 수집

- Actuator + `micrometer-registry-cloudwatch2`를 도입해 `jvm.memory`/`jvm.gc`/`jvm.threads` 지표를 `Gilbut/App` 네임스페이스로 1분 간격 push.
- `/actuator/health`만 인증 없이 노출(기존 swagger permitAll 패턴 재사용). `/actuator/metrics` 등 나머지 엔드포인트는 `exposure.include`에서 제외 + 인증 요구로 이중 차단.
- `CLOUDWATCH_METRICS_ENABLED` 환경변수로 on/off — 로컬은 기본 false(IAM 자격증명이 없어 계속 켜두면 매 1분 인증 실패 로그가 쌓임).

### 2. 배포 파이프라인 반영

- `deploy.yml`의 `.env` 생성 스텝에 `AWS_REGION=ap-northeast-2`, `CLOUDWATCH_METRICS_ENABLED=true`를 리터럴로 추가(민감정보가 아니라 Secret 미사용, 기존 `aws-region: "ap-northeast-2"` 하드코딩 패턴과 일관).
- Terraform은 변경 없음 — `ec2Role`에 이미 `CloudWatchAgentServerPolicy`(PutMetricData 포함)가 붙어있고, IMDS `http_put_response_hop_limit = 2`도 이미 설정돼 있어 컨테이너에서 자격증명/리전 획득이 가능함을 확인.

### 검증

- `./gradlew build`, `./gradlew test` 통과.
- 로컬 `bootRun`: `GET /actuator/health` → `200 {"status":"UP"}`, `CLOUDWATCH_METRICS_ENABLED` 기본 false 상태에서 CloudWatch 관련 에러/시도 로그 없음(export 완전 비활성 확인).
- 회귀 확인: `/actuator/metrics/jvm.memory.used` → 401(비노출+인증 이중 차단), 기존 보호 엔드포인트(`/api/user/me`) → 401(회귀 없음), `/v3/api-docs`(swagger) → 200(회귀 없음).

## 📚 추가 리팩토링 가능성

- CloudWatch 대시보드 위젯(`backend/infra/prod/monitoring.tf`) 미구성 — 배포 후 `aws cloudwatch list-metrics --namespace Gilbut/App`으로 실제 지표명/dimension을 확인한 뒤 기존 `gilbut-oom-observability` 대시보드에 이어 붙일 예정. 특히 기존 "java process RSS" 위젯에 `jvm.memory.used{area=heap}`(합산)를 겹쳐 그리면 실험 문서의 "cgroup 피크 − 힙 committed = 논힙+오버헤드" 산식을 실시간 그래프로 재현할 수 있음.
- `ec2Role`이 `CloudWatchAgentServerPolicy`(호스트 에이전트용)를 커스텀 앱 지표 push에도 재사용 중 — 최소 권한 원칙상 이상적이지 않음(새 정책 추가는 아니라 공격 표면 증가는 없음). 필요시 `cloudwatch:PutMetricData` 전용 인라인 정책으로 교체 검토.
- `docker-compose.prod.yml`의 nginx(20MiB)/certbot(30MiB) mem_limit이 "실측 전 추정치"로 코드 주석에 남아있었는데, 이번에 `docker stats`로 실측해보니 각각 20.4%/32.5%만 사용 중으로 여유가 큼 — 재조정해 `app` 컨테이너 쪽 여유를 늘릴 여지가 있음(문서에 재조정 필요성이 이미 명시돼 있었음).
