### PR TITLE
fix : CloudWatchMeterRegistry 수동 배선

### DIFF
--- a/backend/src/main/java/backend/capstone/global/config/CloudWatchMetricsConfig.java
+++ b/backend/src/main/java/backend/capstone/global/config/CloudWatchMetricsConfig.java
@@ -1,0 +1,53 @@
+package backend.capstone.global.config;
+
+import io.micrometer.cloudwatch2.CloudWatchConfig;
+import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
+import io.micrometer.core.instrument.Clock;
+import java.time.Duration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+
+/**
+ * Spring Boot 3.x는 micrometer-registry-cloudwatch2의 자동 설정을 제공하지 않아
+ * (Prometheus/Datadog 등과 달리 spring-boot-actuator-autoconfigure에 cloudwatch 패키지 자체가 없음)
+ * CloudWatchMeterRegistry를 수동으로 배선한다.
+ */
+@Configuration
+@ConditionalOnProperty(name = "management.cloudwatch.metrics.export.enabled", havingValue = "true")
+public class CloudWatchMetricsConfig {
+
+  @Bean
+  public CloudWatchAsyncClient cloudWatchAsyncClient() {
+    return CloudWatchAsyncClient.create();
+  }
+
+  @Bean
+  public CloudWatchMeterRegistry cloudWatchMeterRegistry(CloudWatchAsyncClient cloudWatchAsyncClient) {
+    CloudWatchConfig config = new CloudWatchConfig() {
+      @Override
+      public String get(String key) {
+        return null;
+      }
+
+      @Override
+      public String namespace() {
+        return "Gilbut/App";
+      }
+
+      @Override
+      public Duration step() {
+        return Duration.ofMinutes(1);
+      }
+
+      @Override
+      public int batchSize() {
+        return 20;
+      }
+    };
+
+    return new CloudWatchMeterRegistry(config, Clock.SYSTEM, cloudWatchAsyncClient);
+  }
+
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -44,13 +44,13 @@ management:
         memory: true
         gc: true
         threads: true
+  # Spring Boot 3.x는 CloudWatch export 자동 설정을 제공하지 않아 이 값은 Spring이 자동으로
+  # 바인딩하지 않는다 — CloudWatchMetricsConfig(global/config)가 @ConditionalOnProperty로
+  # enabled만 직접 읽고, namespace/step/batchSize는 그 클래스 안에 하드코딩돼 있다.
   cloudwatch:
     metrics:
       export:
         enabled: ${CLOUDWATCH_METRICS_ENABLED:false}
-        namespace: Gilbut/App
-        step: 1m
-        batch-size: 20
 
 kakao:
   auth:


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용

### 배경

#67(CloudWatch 관측 도입)을 배포한 뒤 실측해보니 `Gilbut/App` 네임스페이스에 지표가 하나도 찍히지 않았고, 앱 로그에도 CloudWatch 관련 로그가 전혀 없었다. `spring-boot-actuator-autoconfigure-3.2.5.jar`를 직접 열어 확인한 결과, Spring Boot 3.x는 Prometheus/Datadog 등과 달리 **CloudWatch에 대한 자동 설정 클래스를 아예 제공하지 않는다**(`metrics/export/` 하위에 `cloudwatch` 패키지 자체가 없음). 그래서 `application.yml`에 넣었던 `management.cloudwatch.metrics.export.*` 설정은 Spring이 바인딩하지 않는 죽은 값이었고, `CloudWatchMeterRegistry` Bean 자체가 만들어지지 않고 있었다.

### 1. CloudWatchMeterRegistry 수동 배선

- `CloudWatchMetricsConfig`(`global/config`)를 추가해 `CloudWatchAsyncClient`, `CloudWatchMeterRegistry` Bean을 직접 생성.
- `namespace`(`Gilbut/App`)/`step`(1분)/`batchSize`(20)는 `CloudWatchConfig` 익명 구현체 안에 직접 오버라이드 — 생성자 시그니처, `CloudWatchConfig`/`StepRegistryConfig`/`PushRegistryConfig` 인터페이스는 로컬 Gradle 캐시의 jar를 `javap`로 직접 열어 검증했다.
- `management.cloudwatch.metrics.export.enabled`(`CLOUDWATCH_METRICS_ENABLED` 환경변수)만 `@ConditionalOnProperty`로 계속 사용 — 비활성 시 Bean 자체가 생성되지 않아 로컬 개발 흐름은 그대로 유지.
- `application.yml`의 이제 안 쓰이는 `namespace`/`step`/`batch-size` 하위 키는 제거하고, 대신 코드에 있다는 주석만 남김.

### 검증

- `./gradlew build` 통과.
- 로컬 `bootRun`(`CLOUDWATCH_METRICS_ENABLED` 기본 false): CloudWatch 관련 로그 없음, `/actuator/health` 정상 — 비활성 시 Bean 미생성 확인.
- 클래스/인터페이스 시그니처는 실제 jar 바이트코드(`javap`)로 검증해 재현 가능한 근거로 남김(추측 기반 아님).

## 📚 추가 리팩토링 가능성

- 배포 후 `aws cloudwatch get-metric-statistics`로 실제 지표 유입 여부 재확인 필요.
- `CloudWatchConfig`를 익명 클래스로 하드코딩했는데, 네임스페이스 등을 나중에 환경별로 바꿀 일이 생기면 Spring `Environment` 기반으로 리팩터링 검토.
