### PR TITLE
chore : CloudWatch push 진단용 DEBUG 로깅 임시 추가

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,6 +25,9 @@ jwt:
 logging:
   level:
     org.springframework.security: DEBUG
+    # 임시 진단용 — CloudWatch push가 운영에서 조용히 성공/실패하는지 확인한 뒤 제거한다.
+    io.micrometer: DEBUG
+    software.amazon.awssdk: DEBUG
 
 server:
   forward-headers-strategy: framework


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용

### 배경

#68(CloudWatchMeterRegistry 수동 배선) 배포 후 `"publishing metrics for CloudWatchMeterRegistry every 1m"` 로그로 스케줄러가 도는 것까지는 확인했지만, 8분+ 동안 CloudWatch에 데이터포인트가 0개였고 에러 로그도 전혀 없었다. 로컬에서 `io.micrometer`/`software.amazon.awssdk`를 DEBUG로 켜고 재현한 결과, `CloudWatchMeterRegistry`에 미터는 정상 등록되고 실제로 `PutMetricData` 호출을 시도하는 것까지 확인됐다(로컬은 IMDS가 없어 자격증명 단계에서 실패하는 게 정상). micrometer-registry-cloudwatch2는 **성공 시 DEBUG 레벨로만 로그를 남기므로**(바이트코드로 확인: `logger.debug("published {} metrics with namespace:{}", ...)`), 운영 로그가 조용한 게 "실패해서 조용한 것"이 아니라 "성공해도 원래 조용한 것"일 가능성이 있다. 운영에서만 존재하는 실제 IMDS 자격증명 경로의 최종 결과(성공/실패)는 운영에서 DEBUG 로그를 직접 봐야 확정 가능하다.

### 1. 진단용 DEBUG 로깅 추가

- `application.yml`에 `io.micrometer`, `software.amazon.awssdk`를 DEBUG로 추가(임시, 원인 확정 후 되돌릴 예정 — 주석에 명시).

### 검증

- `./gradlew build` 통과.
- 로컬 DEBUG 로깅으로 credential provider chain 순회 및 실제 `PutMetricData` 시도까지 확인(자격증명 없어 최종 실패는 예상된 결과).

## 📚 추가 리팩토링 가능성

- 원인 확정 후 이 커밋의 DEBUG 로깅 레벨을 되돌리는 후속 커밋 필요(운영에 계속 DEBUG로 켜두면 로그 볼륨이 커짐).
