### PR TITLE
chore : CloudWatch push 진단용 DEBUG 로깅 되돌림

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,9 +25,6 @@ jwt:
 logging:
   level:
     org.springframework.security: DEBUG
-    # 임시 진단용 — CloudWatch push가 운영에서 조용히 성공/실패하는지 확인한 뒤 제거한다.
-    io.micrometer: DEBUG
-    software.amazon.awssdk: DEBUG
 
 server:
   forward-headers-strategy: framework


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용

### 배경

#69에서 임시로 켠 `io.micrometer`/`software.amazon.awssdk` DEBUG 로깅으로 운영 로그를 직접 확인한 결과, CloudWatch push는 처음부터 정상 작동 중이었다(`published 20 metrics with namespace:Gilbut/App`, `published 16 metrics with namespace:Gilbut/App` 확인). 앞서 여러 번 "데이터 없음"으로 보였던 건 조회 시 지표 이름에 micrometer-registry-cloudwatch2가 붙이는 접미사(`.value`/`.count`/`.avg`/`.max`/`.sum`)를 빠뜨린 조회 실수 + `list-metrics` 색인 반영 지연이 겹친 결과였다. 원인이 완전히 확정됐으니 진단용으로만 넣었던 DEBUG 로깅을 되돌린다.

### 1. 진단용 DEBUG 로깅 제거

- `application.yml`에서 `io.micrometer`/`software.amazon.awssdk` DEBUG 로깅 제거, `org.springframework.security: DEBUG`만 유지(기존 상태로 복귀).

### 검증

- `./gradlew build` 통과.

## 📚 추가 리팩토링 가능성

- 실제 지표 카디널리티가 41개로 확인됨(CloudWatch 프리티어 10개 초과, 월 약 $9~10 추가 과금 예상) — `jvm.memory`/`jvm.gc`/`jvm.threads`를 태그(area/id/action/cause/state)까지 더 좁힐지, 아니면 이 정도 비용을 감수할지는 별도 논의 필요.
- `monitoring.tf`에 이번에 확인한 정확한 지표 이름(`.value`/`.count` 등 접미사 포함)으로 CloudWatch 대시보드 위젯 추가는 아직 스코프 밖.
