### PR TITLE
refactor : jvm.memory CloudWatch 지표 카디널리티 축소

### DIFF
--- a/backend/src/main/java/backend/capstone/global/config/CloudWatchMetricsConfig.java
+++ b/backend/src/main/java/backend/capstone/global/config/CloudWatchMetricsConfig.java
@@ -3,6 +3,10 @@ package backend.capstone.global.config;
 import io.micrometer.cloudwatch2.CloudWatchConfig;
 import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
 import java.time.Duration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +17,11 @@ import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
  * Spring Boot 3.x는 micrometer-registry-cloudwatch2의 자동 설정을 제공하지 않아
  * (Prometheus/Datadog 등과 달리 spring-boot-actuator-autoconfigure에 cloudwatch 패키지 자체가 없음)
  * CloudWatchMeterRegistry를 수동으로 배선한다.
+ *
+ * jvm.memory의 기본 바인더(JvmMemoryMetrics)는 메모리 풀(Eden/Survivor/Metaspace 등)별로
+ * 태그를 나눠 등록해 CloudWatch 커스텀 지표 개수를 크게 불린다(application.yml에서
+ * management.metrics.enable.jvm.memory=false로 꺼둠). 대신 MemoryMXBean(JVM이 이미 풀
+ * 단위를 합산해주는 API)을 직접 읽어 힙/논힙 각각 하나씩, 태그 없는 집계 Gauge로 대체한다.
  */
 @Configuration
 @ConditionalOnProperty(name = "management.cloudwatch.metrics.export.enabled", havingValue = "true")
@@ -21,6 +30,25 @@ public class CloudWatchMetricsConfig {
   @Bean
   public CloudWatchAsyncClient cloudWatchAsyncClient() {
     return CloudWatchAsyncClient.create();
+  }
+
+  @Bean
+  public MeterBinder totalMemoryMetrics() {
+    MemoryMXBean memoryMxBean = ManagementFactory.getMemoryMXBean();
+    return registry -> {
+      Gauge.builder("jvm.memory.heap.used", memoryMxBean,
+          bean -> bean.getHeapMemoryUsage().getUsed()).register(registry);
+      Gauge.builder("jvm.memory.heap.committed", memoryMxBean,
+          bean -> bean.getHeapMemoryUsage().getCommitted()).register(registry);
+      Gauge.builder("jvm.memory.heap.max", memoryMxBean,
+          bean -> bean.getHeapMemoryUsage().getMax()).register(registry);
+      Gauge.builder("jvm.memory.nonheap.used", memoryMxBean,
+          bean -> bean.getNonHeapMemoryUsage().getUsed()).register(registry);
+      Gauge.builder("jvm.memory.nonheap.committed", memoryMxBean,
+          bean -> bean.getNonHeapMemoryUsage().getCommitted()).register(registry);
+      Gauge.builder("jvm.memory.nonheap.max", memoryMxBean,
+          bean -> bean.getNonHeapMemoryUsage().getMax()).register(registry);
+    };
   }
 
   @Bean

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,7 +41,9 @@ management:
     enable:
       all: false
       jvm:
-        memory: true
+        # 풀별(Eden/Survivor/Metaspace 등)로 태그가 갈라져 CloudWatch 지표 수를 크게 불려서
+        # 끈다 — 대신 CloudWatchMetricsConfig의 집계 Gauge(jvm.memory.heap.*, .nonheap.*)를 쓴다.
+        memory: false
         gc: true
         threads: true
   # Spring Boot 3.x는 CloudWatch export 자동 설정을 제공하지 않아 이 값은 Spring이 자동으로


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용

### 배경

배포 후 실측한 `Gilbut/App` 네임스페이스의 실제 CloudWatch 커스텀 지표가 총 42개로 확인됐다. 그중 19개(`jvm.memory.{used,committed,max}.value` 18개 + `jvm.memory.usage.after.gc.value` 1개)가 힙/논힙 메모리 풀(Eden/Survivor/Tenured Gen/Metaspace/CodeCache/Compressed Class Space)별로 태그가 갈라진 결과였다. CloudWatch 프리티어(10개)를 크게 초과해 월 약 $9~10의 추가 과금이 예상되는 상태였다.

### 1. jvm.memory 지표를 힙/논힙 합계로 축소

- `CloudWatchMetricsConfig`에 `MemoryMXBean`(JVM이 이미 풀 단위를 합산해주는 표준 API) 기반 집계 `Gauge` 6개(`jvm.memory.heap.{used,committed,max}`, `jvm.memory.nonheap.{used,committed,max}`) 추가 — 태그 없이 딱 6개의 지표로 힙/논힙 각각의 실제 사용량·커밋량·상한을 본다.
- `application.yml`에서 풀별 세부 바인더(`management.metrics.enable.jvm.memory`)는 끔 — 대신 풀 단위로 파고들 필요가 있을 때는(이번 부팅 버스트 조사처럼) 임시 GC 로그/디버그 로깅으로 대체하는 것을 전제로 한다.

이번 변경으로 `jvm.memory` 관련 지표는 19개 → 6개로 줄어든다(`jvm.gc`/`jvm.threads` 그룹은 이번 스코프 밖 — 여전히 카디널리티가 있다).

### 검증

- `./gradlew build` 통과.
- 로컬 `bootRun`(`CLOUDWATCH_METRICS_ENABLED=true`, `io.micrometer` DEBUG): 새 Gauge Bean 등록 관련 에러 없이 정상 기동, `/actuator/health` 200 확인.

## 📚 추가 리팩토링 가능성

- `jvm.gc`(13개)/`jvm.threads`(10개) 그룹도 여전히 프리티어를 넘는 카디널리티를 차지한다 — 필요시 같은 방식(태그 없는 집계 지표로 대체 또는 화이트리스트 추가 축소)으로 후속 정리 가능.
