### PR TITLE
refactor : CloudWatch 지표를 프리티어(10개) 안으로 최종 축소

### DIFF
--- a/backend/infra/prod/monitoring.tf
+++ b/backend/infra/prod/monitoring.tf
@@ -43,10 +43,14 @@ resource "aws_ssm_parameter" "cw_agent_config" {
           # mem_used_percent는 buff/cache를 전부 "안 쓴 것"으로 계산해 캐시 고갈 상황을
           # 못 잡아낸다(2026-07-14 11:34 OOM-kill 사건 실측으로 확인). mem_available_percent는
           # 커널이 실제 회수 가능 여부까지 반영한 수치라 훨씬 신뢰할 수 있는 조기 경보 지표다.
-          measurement = ["mem_used_percent", "mem_available_percent", "mem_available", "mem_used", "mem_total"]
+          # mem_used_percent/mem_available/mem_used/mem_total은 CloudWatch 커스텀 지표
+          # 프리티어(계정+리전 통틀어 10개)를 맞추기 위해 제거 — mem_high/mem_warning 알람이
+          # 쓰는 mem_available_percent만 남긴다.
+          measurement = ["mem_available_percent"]
         }
         swap = {
-          measurement = ["swap_used_percent", "swap_used"]
+          # swap_used는 같은 이유로 제거 — swap_high 알람이 쓰는 swap_used_percent만 남긴다.
+          measurement = ["swap_used_percent"]
         }
         cpu = {
           measurement = ["usage_active"]
@@ -82,33 +86,13 @@ resource "aws_ssm_parameter" "cw_agent_config" {
 }
 
 # ── 메트릭 필터: 로그 → 메트릭 ───────────────────────────────
-# 커널 OOM-killer 발화. "?" 는 OR(둘 중 하나라도 포함하는 라인 매칭).
-resource "aws_cloudwatch_log_metric_filter" "oom_kill" {
-  name           = "gilbut-oom-kill"
-  log_group_name = aws_cloudwatch_log_group.kern.name
-  pattern        = "?\"invoked oom-killer\" ?\"Out of memory: Killed process\""
-
-  metric_transformation {
-    name          = "OOMKillCount"
-    namespace     = "Gilbut/EC2"
-    value         = "1"
-    default_value = "0"
-  }
-}
-
-# docker events 로거가 남기는 "exitCode=137"(SIGKILL, 컨테이너 OOM 사망) 라인.
-resource "aws_cloudwatch_log_metric_filter" "container_die" {
-  name           = "gilbut-container-die"
-  log_group_name = aws_cloudwatch_log_group.docker_events.name
-  pattern        = "\"exitCode=137\""
-
-  metric_transformation {
-    name          = "ContainerDieCount"
-    namespace     = "Gilbut/EC2"
-    value         = "1"
-    default_value = "0"
-  }
-}
+# OOMKillCount/ContainerDieCount 로그 지표 필터는 CloudWatch 커스텀 지표 프리티어
+# (계정+리전 통틀어 10개)를 맞추기 위해 제거했다(2026-08-04). 커널 OOM-killer 발화
+# ("invoked oom-killer"/"Out of memory: Killed process")와 컨테이너 OOM 사망(exitCode=137)
+# 로그 자체는 kern/docker_events 로그 그룹에 계속 수집되므로, 필요시 CloudWatch Logs
+# Insights로 수동 조회하거나 로그 지표 필터를 다시 만들면 복구 가능하다. 다만 이 변경으로
+# gilbut-oom-kill 알람(Slack 긴급 알림)은 더 이상 발동하지 않는다 — mem_high/mem_warning/
+# swap_high 알람은 그대로 유지된다.
 
 # ── 알림 채널: SNS → AWS Chatbot → Slack ─────────────────────
 # 같은 계정 내 CloudWatch 알람은 SNS가 기본 부여하는 토픽 정책(aws:SourceOwner 조건)만으로
@@ -129,21 +113,8 @@ resource "aws_chatbot_slack_channel_configuration" "alerts" {
 }
 
 # ── 경보 (SNS → Slack 알림) ──────────────────────────────────
-resource "aws_cloudwatch_metric_alarm" "oom_kill" {
-  alarm_name          = "gilbut-oom-kill"
-  alarm_description   = "❗ [긴급] 커널 OOM-killer 발화 감지"
-  namespace           = "Gilbut/EC2"
-  metric_name         = "OOMKillCount"
-  statistic           = "Sum"
-  period              = 60
-  evaluation_periods  = 1
-  threshold           = 1
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  treat_missing_data  = "notBreaching"
-
-  alarm_actions = [aws_sns_topic.alerts.arn]
-  ok_actions    = [aws_sns_topic.alerts.arn]
-}
+# gilbut-oom-kill(OOMKillCount 기반) 알람은 지표 프리티어를 맞추기 위해 위의 로그 지표
+# 필터와 함께 제거했다 — 커널 OOM-killer 발화에 대한 실시간 Slack 알림은 더 이상 없다.
 
 resource "aws_cloudwatch_metric_alarm" "mem_high" {
   alarm_name          = "gilbut-mem-high"
@@ -219,14 +190,13 @@ resource "aws_cloudwatch_dashboard" "oom" {
         width  = 12
         height = 6
         properties = {
-          title  = "Memory & Swap used %"
+          title  = "Memory & Swap available/used %"
           region = var.region
           view   = "timeSeries"
           period = 60
           stat   = "Average"
           yAxis  = { left = { min = 0, max = 100 } }
           metrics = [
-            [{ expression = "SEARCH('{Gilbut/EC2,InstanceId} MetricName=\"mem_used_percent\"', 'Average', 60)", label = "mem_used_percent", id = "m1" }],
             [{ expression = "SEARCH('{Gilbut/EC2,InstanceId} MetricName=\"mem_available_percent\"', 'Average', 60)", label = "mem_available_percent", id = "m3" }],
             [{ expression = "SEARCH('{Gilbut/EC2,InstanceId} MetricName=\"swap_used_percent\"', 'Average', 60)", label = "swap_used_percent", id = "m2" }]
           ]
@@ -273,24 +243,6 @@ resource "aws_cloudwatch_dashboard" "oom" {
         type   = "metric"
         x      = 12
         y      = 6
-        width  = 12
-        height = 6
-        properties = {
-          title  = "OOM kills & Container deaths (per min)"
-          region = var.region
-          view   = "timeSeries"
-          period = 60
-          stat   = "Sum"
-          metrics = [
-            ["Gilbut/EC2", "OOMKillCount", { label = "OOMKillCount" }],
-            ["Gilbut/EC2", "ContainerDieCount", { label = "ContainerDieCount (exit137)" }]
-          ]
-        }
-      },
-      {
-        type   = "metric"
-        x      = 0
-        y      = 12
         width  = 12
         height = 6
         properties = {

--- a/backend/src/main/java/backend/capstone/global/config/CloudWatchMetricsConfig.java
+++ b/backend/src/main/java/backend/capstone/global/config/CloudWatchMetricsConfig.java
@@ -5,9 +5,11 @@ import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.time.Duration;
+import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,10 +20,11 @@ import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
  * (Prometheus/Datadog 등과 달리 spring-boot-actuator-autoconfigure에 cloudwatch 패키지 자체가 없음)
  * CloudWatchMeterRegistry를 수동으로 배선한다.
  *
- * jvm.memory의 기본 바인더(JvmMemoryMetrics)는 메모리 풀(Eden/Survivor/Metaspace 등)별로
- * 태그를 나눠 등록해 CloudWatch 커스텀 지표 개수를 크게 불린다(application.yml에서
- * management.metrics.enable.jvm.memory=false로 꺼둠). 대신 MemoryMXBean(JVM이 이미 풀
- * 단위를 합산해주는 API)을 직접 읽어 힙/논힙 각각 하나씩, 태그 없는 집계 Gauge로 대체한다.
+ * jvm.memory/jvm.gc의 기본 바인더는 메모리 풀(Eden/Survivor/Metaspace 등)·GC 종류별로 태그를
+ * 나눠 등록해 CloudWatch 커스텀 지표 개수를 크게 불린다(application.yml에서
+ * management.metrics.enable.jvm.memory/jvm.gc=false로 꺼둠). 대신 MemoryMXBean/
+ * GarbageCollectorMXBean(JVM이 이미 풀·GC 종류를 합산해주는 API)을 직접 읽어 태그 없는
+ * 집계 지표로 대체한다 — CloudWatch 프리티어(계정+리전 통틀어 10개)를 맞추기 위함.
  */
 @Configuration
 @ConditionalOnProperty(name = "management.cloudwatch.metrics.export.enabled", havingValue = "true")
@@ -40,14 +43,23 @@ public class CloudWatchMetricsConfig {
           bean -> bean.getHeapMemoryUsage().getUsed()).register(registry);
       Gauge.builder("jvm.memory.heap.committed", memoryMxBean,
           bean -> bean.getHeapMemoryUsage().getCommitted()).register(registry);
-      Gauge.builder("jvm.memory.heap.max", memoryMxBean,
-          bean -> bean.getHeapMemoryUsage().getMax()).register(registry);
       Gauge.builder("jvm.memory.nonheap.used", memoryMxBean,
           bean -> bean.getNonHeapMemoryUsage().getUsed()).register(registry);
       Gauge.builder("jvm.memory.nonheap.committed", memoryMxBean,
           bean -> bean.getNonHeapMemoryUsage().getCommitted()).register(registry);
-      Gauge.builder("jvm.memory.nonheap.max", memoryMxBean,
-          bean -> bean.getNonHeapMemoryUsage().getMax()).register(registry);
+    };
+  }
+
+  @Bean
+  public MeterBinder totalGcMetrics() {
+    List<GarbageCollectorMXBean> gcBeans = ManagementFactory.getGarbageCollectorMXBeans();
+    return registry -> {
+      Gauge.builder("jvm.gc.pause.count", gcBeans,
+          beans -> beans.stream().mapToLong(GarbageCollectorMXBean::getCollectionCount).sum())
+          .register(registry);
+      Gauge.builder("jvm.gc.pause.time", gcBeans,
+          beans -> beans.stream().mapToLong(GarbageCollectorMXBean::getCollectionTime).sum())
+          .register(registry);
     };
   }
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,11 +41,11 @@ management:
     enable:
       all: false
       jvm:
-        # 풀별(Eden/Survivor/Metaspace 등)로 태그가 갈라져 CloudWatch 지표 수를 크게 불려서
-        # 끈다 — 대신 CloudWatchMetricsConfig의 집계 Gauge(jvm.memory.heap.*, .nonheap.*)를 쓴다.
+        # 풀/GC종류별로 태그가 갈라져 CloudWatch 지표 수를 크게 불려서 끈다 — 대신
+        # CloudWatchMetricsConfig의 집계 Gauge(jvm.memory.heap/nonheap.*, jvm.gc.pause.*)를 쓴다.
         memory: false
-        gc: true
-        threads: true
+        gc: false
+        threads: false
   # Spring Boot 3.x는 CloudWatch export 자동 설정을 제공하지 않아 이 값은 Spring이 자동으로
   # 바인딩하지 않는다 — CloudWatchMetricsConfig(global/config)가 @ConditionalOnProperty로
   # enabled만 직접 읽고, namespace/step/batchSize는 그 클래스 안에 하드코딩돼 있다.


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용

### 배경

`Gilbut/App`(jvm.memory 축소 후에도 여전히 jvm.gc 13개 + jvm.threads 10개)와 `Gilbut/EC2`(11개)를 합치면 CloudWatch 커스텀 지표 프리티어(계정+리전 통틀어 10개)를 크게 초과했다. 두 네임스페이스를 합쳐 정확히 10개(`Gilbut/EC2` 4개 + `Gilbut/App` 6개)로 맞춘다.

### 1. jvm.gc/jvm.threads를 집계값으로 축소 (Gilbut/App: 13+10 → 2+0)

- `CloudWatchMetricsConfig`에 `GarbageCollectorMXBean` 기반 집계 Gauge 2개(`jvm.gc.pause.count`, `jvm.gc.pause.time` — 전체 GC 종류 합산) 추가.
- `jvm.threads`는 완전히 제거(화면상 큰 정보 손실은 없다고 판단 — 필요시 별도 조사 때만 임시로 다시 켬).
- `application.yml`에서 `management.metrics.enable.jvm.gc/threads`를 `false`로 끔(기본 풀/GC종류별 바인더 비활성화).
- `jvm.memory.heap/nonheap.max`도 함께 제거(used/committed만 남김) — 예산을 6개(4+2)로 맞추기 위함.

### 2. Gilbut/EC2에서 OOMKillCount/ContainerDieCount 제거 (11 → 4)

- 로그 지표 필터 2개(`gilbut-oom-kill`, `gilbut-container-die`)와 `gilbut-oom-kill` 알람 제거.
- **`terraform apply`로 이미 반영 완료**, EC2의 CloudWatch Agent도 `fetch-config`로 재적용함(이 PR 머지와 무관하게 운영에 실시간 반영됨 — Terraform은 GitHub Actions 파이프라인을 안 타므로 코드가 develop에 없어도 인프라 자체는 이미 바뀐 상태였음, 이 PR은 코드 히스토리 정합성을 위한 반영).
- kern/docker-events 로그 자체는 계속 수집되므로 필요시 CloudWatch Logs Insights로 복구 가능.
- **커널 OOM-killer 발화에 대한 Slack 긴급 알림(`gilbut-oom-kill`)은 더 이상 없다** — `mem_high`/`mem_warning`/`swap_high` 알람은 유지.

### 검증

- `./gradlew build` 통과.
- 로컬 `bootRun`(`CLOUDWATCH_METRICS_ENABLED=true`, `io.micrometer` DEBUG): 새 GC 집계 Gauge 등록 관련 에러 없이 정상 기동.
- `terraform plan`으로 의도한 리소스만 변경/삭제됨을 확인 후 `-target`으로 apply(무관한 state drift인 `aws_chatbot_slack_channel_configuration` 리소스는 건드리지 않음).

## 📚 추가 리팩토링 가능성

- 현재 구성이 정확히 10개라 여유가 전혀 없음 — 향후 다른 커스텀 지표를 추가하려면 기존 것 중 하나를 빼야 함.
- `aws_chatbot_slack_channel_configuration.alerts`에 무관한 state drift(`logging_level: ERROR→NONE` 등)가 있음을 발견 — 원인 파악 및 정리는 별도 작업으로 남김.
