### PR TITLE
fix : CloudWatch 커스텀 지표 자체 필터 충돌 문제 해결

### DIFF
--- a/backend/docs/tech/infra/oom-repro-evidence/production/2026-08-04-운영-힙논힙-실측.md
+++ b/backend/docs/tech/infra/oom-repro-evidence/production/2026-08-04-운영-힙논힙-실측.md
@@ -5,8 +5,15 @@
 CloudWatch로 `jvm.memory.*` 커스텀 지표를 push하도록 배선했으나(관련 PR #67~#72),
 `CloudWatchMetricsConfig`에 직접 등록한 커스텀 집계 Gauge(`jvm.memory.heap.*`,
 `jvm.gc.pause.*`)가 실제로는 CloudWatch에 데이터가 한 번도 들어오지 않는 문제가
-발견됐다(원인 미확정, 별도 조사 중). 이 공백을 메우기 위해 CloudWatch를 거치지 않고
-**JVM에 직접 진단 도구로 붙어 실시간 힙/논힙 수치를 실측**했다.
+발견됐다. 이 공백을 메우기 위해 CloudWatch를 거치지 않고 **JVM에 직접 진단 도구로 붙어
+실시간 힙/논힙 수치를 실측**했다.
+
+**원인은 이후(같은 날) 확정됐다** — `management.metrics.enable.*`는 "누가 등록했는지"가
+아니라 "이름이 무엇인지"만 보는 `MeterFilter`라서, 커스텀 Gauge 이름을 `jvm.memory.*`/
+`jvm.gc.*`로 지었더니 그걸 끄려고 설정한 `management.metrics.enable.jvm.memory/gc=false`
+필터에 자기 자신도 걸려 조용히 등록이 거부됐다(예외 없이 등록만 안 됨). 지표 이름을
+`app.memory.*`/`app.gc.*`로 바꾸고 `management.metrics.enable.app=true`를 추가해 해결—
+자세한 진단 과정은 세션 대화 참고, 수정은 PR #73.
 
 ## 측정 대상
 
@@ -94,8 +101,6 @@ CloudWatch에서 관측했던 GC 태그(`gc=MarkSweepCompact`, `gc=Copy`)도 Ser
 
 ## 남은 공백
 
-- CloudWatch 커스텀 Gauge(`jvm.memory.heap.*`, `jvm.gc.pause.*`)가 왜 실제로 데이터를
-  안 보내는지는 이 문서에서 다루지 않음 — 별도 조사 필요.
 - 이번 측정은 idle 스냅샷 1회다. 부팅 버스트 순간의 라이브 피크는 이 방식(사후 접속)으로는
   못 잡는다 — 그건 로컬 실험(`../local/2026-07-17-부팅버스트-실험요약.md`)의 GC 로그
   방식이 유일한 방법이었다.

--- a/backend/docs/tech/infra/oom-repro-evidence/production/2026-08-04-운영-힙논힙-실측.md
+++ b/backend/docs/tech/infra/oom-repro-evidence/production/2026-08-04-운영-힙논힙-실측.md
@@ -1,0 +1,103 @@
+# 운영 EC2 힙/논힙 실측 (2026-08-04)
+
+## 배경
+
+CloudWatch로 `jvm.memory.*` 커스텀 지표를 push하도록 배선했으나(관련 PR #67~#72),
+`CloudWatchMetricsConfig`에 직접 등록한 커스텀 집계 Gauge(`jvm.memory.heap.*`,
+`jvm.gc.pause.*`)가 실제로는 CloudWatch에 데이터가 한 번도 들어오지 않는 문제가
+발견됐다(원인 미확정, 별도 조사 중). 이 공백을 메우기 위해 CloudWatch를 거치지 않고
+**JVM에 직접 진단 도구로 붙어 실시간 힙/논힙 수치를 실측**했다.
+
+## 측정 대상
+
+- 인스턴스: `i-09cf2646d48142d46`(t3.micro, `mem_limit: 590m`)
+- 측정 시점 기준 실행 중이던 컨테이너: PR #72(`refactor: jvm.gc/jvm.threads CloudWatch
+  지표를 집계값으로 축소`) 배포분, 컨테이너 시작 시각 `2026-08-04T07:44:00Z`
+- 측정 시각: 컨테이너 기동 후 약 30분 경과 시점(idle, 별다른 트래픽 없음)
+- 힙 상한: `-Xmx` 미지정, JVM 컨테이너 인식 ergonomics(`MaxRAMPercentage` 기본
+  25%)로 `590m`의 25% ≈ 147.5MB (`backend/Dockerfile` 참고)
+
+## 측정 방법
+
+이 이미지(`eclipse-temurin:21-jre`)에는 `jcmd`가 없어(기존 로컬 실험에서도 동일하게
+확인됨), 아래 두 가지 방식으로 **읽기 전용 진단**을 수행했다. 둘 다 대상 프로세스를
+정지시키거나 부하를 주지 않는다.
+
+1. **`jcmd` — 같은 PID/네트워크 네임스페이스를 공유하는 임시 `eclipse-temurin:21-jdk`
+   컨테이너로 붙음**:
+   ```bash
+   docker run --rm --pid=container:myapp --network=container:myapp --user root \
+     eclipse-temurin:21-jdk jcmd 1 GC.heap_info
+   docker run --rm --pid=container:myapp --user root \
+     eclipse-temurin:21-jdk jcmd 1 VM.metaspace
+   ```
+2. **JMX(`MemoryPoolMXBean.getPeakUsage()`) — 같은 방식으로 로컬 관리 에이전트에
+   붙어 부팅 이후 각 메모리 풀의 최고치를 조회**(`VirtualMachine.attach` +
+   `startLocalManagementAgent` + JMX 연결, `--network=container:myapp` 필수 — 로컬
+   관리 에이전트의 RMI 커넥터가 대상 컨테이너의 내부 IP로 바인딩되기 때문에 네트워크
+   네임스페이스를 공유하지 않으면 연결이 타임아웃된다).
+
+## 측정 결과
+
+### 현재 스냅샷 (`jcmd GC.heap_info`)
+
+| 영역 | total/capacity | used |
+|---|---:|---:|
+| Eden Space | 40,512 KB | 36% |
+| Survivor(from) | 4,992 KB | 31% |
+| Tenured Gen | 101,056 KB | 61% (62,518 KB) |
+| **힙 합계** | **146,560 KB (143.1 MiB)** | **78,952 KB (77.1 MiB)** |
+| Metaspace | committed 112,896 KB | used 111,536 KB |
+| Class space | committed 16,512 KB | used 16,011 KB |
+| **논힙 합계**(Metaspace+class space) | **committed 129,408 KB (126.4 MiB)** | **used 127,547 KB (124.6 MiB)** |
+
+**힙보다 논힙(Metaspace)이 더 크다** — used 기준 124.6MiB vs 77.1MiB.
+
+### 부팅 이후 최고치 (`MemoryPoolMXBean.getPeakUsage()`)
+
+| 풀 | peak used | peak committed |
+|---|---:|---:|
+| Metaspace | 110 MB | 111 MB |
+| Compressed Class Space | 15 MB | 16 MB |
+| **Metaspace 계** | **125 MB** | **127 MB** |
+| Tenured Gen | 61 MB | 98 MB |
+| Eden Space | 39 MB | 39 MB |
+| Survivor Space | 3 MB | 4 MB |
+| CodeCache(참고, 논힙이지만 Metaspace와 별도 풀) | 17 MB | 18 MB |
+
+현재 스냅샷과 최고치가 거의 동일하다 — **이 측정 시점 기준으로 Metaspace는 더 이상
+자라지 않고 안정화된 상태**로 보인다(부팅 시 클래스 로딩이 대부분 끝난 뒤 유지 구간).
+
+### 프로세스 전체 RSS (`/proc/1/status`)
+
+| 항목 | 값 |
+|---|---:|
+| VmRSS(측정 시점 현재) | 197,388 KB (192.8 MiB) |
+| VmHWM(부팅 이후 최고치) | 344,152 KB (336.1 MiB) |
+
+### `VM.metaspace` 상세 설정값 (`jcmd VM.metaspace`)
+
+- 클래스 로더 511개, 클래스 25,096개(그중 1,418개는 CDS 공유 아카이브에서 로드)
+- **`MaxMetaspaceSize: unlimited`** — 논힙 상한이 걸려있지 않음을 재확인(과거 OOM
+  사건들의 반복된 원인)
+- `CompressedClassSpaceSize: 1.00 GB`(reserved, 실제 committed는 16MB 수준 —
+  가상주소 예약일 뿐 실사용량 아님)
+- `CDS: on` — Class Data Sharing 활성 상태(추가 최적화 여지는 `docs/...` 별도 조사 필요)
+
+## 참고 — 확인된 GC 종류
+
+`jcmd GC.heap_info`가 `def new generation`/`tenured generation` 용어를 쓴다 — 이건
+**Serial GC**다(G1GC였다면 `garbage-first heap`으로 표시됨). t3.micro가 1 vCPU라 JVM
+ergonomics가 병렬성이 필요한 G1 대신 Serial을 자동 선택한 것으로 보인다. 이전에
+CloudWatch에서 관측했던 GC 태그(`gc=MarkSweepCompact`, `gc=Copy`)도 Serial GC의
+컬렉터 이름과 정확히 일치해 교차 확인된다.
+
+## 남은 공백
+
+- CloudWatch 커스텀 Gauge(`jvm.memory.heap.*`, `jvm.gc.pause.*`)가 왜 실제로 데이터를
+  안 보내는지는 이 문서에서 다루지 않음 — 별도 조사 필요.
+- 이번 측정은 idle 스냅샷 1회다. 부팅 버스트 순간의 라이브 피크는 이 방식(사후 접속)으로는
+  못 잡는다 — 그건 로컬 실험(`../local/2026-07-17-부팅버스트-실험요약.md`)의 GC 로그
+  방식이 유일한 방법이었다.
+- 이번에 쓴 "임시 JDK 컨테이너로 PID/네트워크 네임스페이스 공유 + jcmd/JMX 부착" 기법은
+  운영 JVM 진단이 막혔을 때 재사용 가능한 일반적인 방법이라 기록해둔다.

--- a/backend/src/main/java/backend/capstone/global/config/CloudWatchMetricsConfig.java
+++ b/backend/src/main/java/backend/capstone/global/config/CloudWatchMetricsConfig.java
@@ -25,6 +25,13 @@ import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
  * management.metrics.enable.jvm.memory/jvm.gc=false로 꺼둠). 대신 MemoryMXBean/
  * GarbageCollectorMXBean(JVM이 이미 풀·GC 종류를 합산해주는 API)을 직접 읽어 태그 없는
  * 집계 지표로 대체한다 — CloudWatch 프리티어(계정+리전 통틀어 10개)를 맞추기 위함.
+ *
+ * 지표 이름을 반드시 "jvm.memory"/"jvm.gc"가 아닌 "app.memory"/"app.gc"로 지어야 한다 —
+ * management.metrics.enable.*는 "누가 등록했는지"가 아니라 "이름이 무엇인지"로 걸러내는
+ * MeterFilter라서, jvm.memory/jvm.gc를 끄면 이 커스텀 Gauge도 이름이 겹쳐 조용히
+ * 거부(DENY)당한다(에러 없이 등록만 안 됨 — 2026-08-04 실제로 이 문제로 데이터가
+ * 하나도 안 들어온 적이 있음). application.yml의 management.metrics.enable.app=true와 짝을
+ * 이룬다.
  */
 @Configuration
 @ConditionalOnProperty(name = "management.cloudwatch.metrics.export.enabled", havingValue = "true")
@@ -39,13 +46,13 @@ public class CloudWatchMetricsConfig {
   public MeterBinder totalMemoryMetrics() {
     MemoryMXBean memoryMxBean = ManagementFactory.getMemoryMXBean();
     return registry -> {
-      Gauge.builder("jvm.memory.heap.used", memoryMxBean,
+      Gauge.builder("app.memory.heap.used", memoryMxBean,
           bean -> bean.getHeapMemoryUsage().getUsed()).register(registry);
-      Gauge.builder("jvm.memory.heap.committed", memoryMxBean,
+      Gauge.builder("app.memory.heap.committed", memoryMxBean,
           bean -> bean.getHeapMemoryUsage().getCommitted()).register(registry);
-      Gauge.builder("jvm.memory.nonheap.used", memoryMxBean,
+      Gauge.builder("app.memory.nonheap.used", memoryMxBean,
           bean -> bean.getNonHeapMemoryUsage().getUsed()).register(registry);
-      Gauge.builder("jvm.memory.nonheap.committed", memoryMxBean,
+      Gauge.builder("app.memory.nonheap.committed", memoryMxBean,
           bean -> bean.getNonHeapMemoryUsage().getCommitted()).register(registry);
     };
   }
@@ -54,10 +61,10 @@ public class CloudWatchMetricsConfig {
   public MeterBinder totalGcMetrics() {
     List<GarbageCollectorMXBean> gcBeans = ManagementFactory.getGarbageCollectorMXBeans();
     return registry -> {
-      Gauge.builder("jvm.gc.pause.count", gcBeans,
+      Gauge.builder("app.gc.pause.count", gcBeans,
           beans -> beans.stream().mapToLong(GarbageCollectorMXBean::getCollectionCount).sum())
           .register(registry);
-      Gauge.builder("jvm.gc.pause.time", gcBeans,
+      Gauge.builder("app.gc.pause.time", gcBeans,
           beans -> beans.stream().mapToLong(GarbageCollectorMXBean::getCollectionTime).sum())
           .register(registry);
     };

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -42,10 +42,14 @@ management:
       all: false
       jvm:
         # 풀/GC종류별로 태그가 갈라져 CloudWatch 지표 수를 크게 불려서 끈다 — 대신
-        # CloudWatchMetricsConfig의 집계 Gauge(jvm.memory.heap/nonheap.*, jvm.gc.pause.*)를 쓴다.
+        # CloudWatchMetricsConfig의 집계 Gauge(app.memory.heap/nonheap.*, app.gc.pause.*)를 쓴다.
         memory: false
         gc: false
         threads: false
+      # CloudWatchMetricsConfig의 커스텀 Gauge는 이름이 app.*라 all:false의 영향을 받는다 —
+      # 반드시 명시적으로 허용해야 한다(잠깐 jvm.memory/jvm.gc와 이름이 겹쳐서 이 필터에
+      # 스스로 걸려 조용히 등록이 안 되는 문제가 있었다 — 2026-08-04).
+      app: true
   # Spring Boot 3.x는 CloudWatch export 자동 설정을 제공하지 않아 이 값은 Spring이 자동으로
   # 바인딩하지 않는다 — CloudWatchMetricsConfig(global/config)가 @ConditionalOnProperty로
   # enabled만 직접 읽고, namespace/step/batchSize는 그 클래스 안에 하드코딩돼 있다.


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용

### 배경

#67~#72로 배선한 CloudWatch push가 배포 후 실제로 CloudWatch에 데이터를 한 번도 보내지 않았다. 배포된 jar가 올바른 코드를 담고 있고, 레지스트리 스케줄러도 정상 기동하고, 에러 로그도 전혀 없어 원인을 특정하기 어려웠다. 디버그 프린트를 임시로 심어 로컬 재현한 결과, `Gauge.builder(...).register(registry)`를 호출해도 `registry.getMeters().size()`가 0으로 남는 것을 직접 확인했다.

### 1. 근본 원인: 커스텀 지표가 자기 자신을 끄는 필터에 걸림

`management.metrics.enable.*`는 **누가 등록했는지가 아니라 지표 이름만 보는 `MeterFilter`**다. `CloudWatchMetricsConfig`의 커스텀 집계 Gauge를 `jvm.memory.*`/`jvm.gc.*`로 명명했는데, 이건 하필 기본 풀별 바인더를 끄려고 설정한 `management.metrics.enable.jvm.memory/gc=false`와 이름이 겹쳐 **커스텀 지표 자신도 같은 필터에 DENY당했다.** Micrometer는 필터가 거부하면 예외 없이 조용히 등록을 스킵하기 때문에 로그에 아무 흔적도 안 남았다.

### 2. 수정

- 지표 이름을 `jvm.memory.*`/`jvm.gc.*` → `app.memory.*`/`app.gc.*`로 변경(기본 바인더 접두사와 안 겹치게).
- `application.yml`에 `management.metrics.enable.app: true` 추가(새 접두사도 `all: false`의 영향을 받으므로 명시적으로 허용).
- 클래스 상단 주석에 이 함정을 기록해 재발 방지.

### 검증

- `./gradlew build` 통과.
- 로컬 `bootRun`(`CLOUDWATCH_METRICS_ENABLED=true`): 수정 전엔 `registry.getMeters().size()=0`이었던 게, 수정 후 재현에서 **credential provider chain이 실제로 3회 호출됨을 확인**(= `metricData()`가 더 이상 비어있지 않다는 확실한 증거. 로컬은 IMDS가 없어 최종 인증 자체는 실패하는 게 정상).

## 📚 추가 리팩토링 가능성

- 배포 후 실제로 `Gilbut/App` 네임스페이스에 `app.memory.*`/`app.gc.*` 6개 지표가 들어오는지 최종 확인 필요.
- `management.metrics.enable.*`가 이름 기반 필터라는 함정은 커스텀 지표를 추가할 때마다 재발 가능 — 새 커스텀 지표를 추가할 땐 반드시 기존에 끈 접두사와 겹치지 않는지 확인하는 체크리스트화 검토.
