### PR TITLE
feat : CloudWatch 대시보드에 JVM 힙/논힙/GC 위젯 추가

### DIFF
--- a/backend/infra/prod/monitoring.tf
+++ b/backend/infra/prod/monitoring.tf
@@ -226,7 +226,7 @@ resource "aws_cloudwatch_dashboard" "oom" {
         width  = 12
         height = 6
         properties = {
-          title  = "java process RSS (bytes)"
+          title  = "java process RSS vs JVM committed (bytes)"
           region = var.region
           view   = "timeSeries"
           period = 60
@@ -235,7 +235,11 @@ resource "aws_cloudwatch_dashboard" "oom" {
             # {Namespace,Dim1,Dim2,...} 스키마 검색은 "정확히 이 dimension들만 가진" 메트릭을 찾는다.
             # procstat_memory_rss는 dimension이 3개(InstanceId·process_name·pattern)라 dimension을
             # 하나도 안 적은 {Gilbut/EC2}(=dimension 0개 스키마)와 매칭되지 않아 늘 빈 결과였다.
-            [{ expression = "SEARCH('{Gilbut/EC2,InstanceId,process_name,pattern} MetricName=\"procstat_memory_rss\"', 'Average', 60)", label = "java RSS", id = "r1" }]
+            [{ expression = "SEARCH('{Gilbut/EC2,InstanceId,process_name,pattern} MetricName=\"procstat_memory_rss\"', 'Average', 60)", label = "java RSS", id = "r1" }],
+            # app.memory.heap/nonheap.committed는 태그 없는 단일 Gauge라 SEARCH 없이 직접 참조.
+            # RSS − (heap.committed + nonheap.committed) = 순수 네이티브 오버헤드(스레드 스택 등)다.
+            ["Gilbut/App", "app.memory.heap.committed.value", { label = "heap committed" }],
+            ["Gilbut/App", "app.memory.nonheap.committed.value", { label = "nonheap committed" }]
           ]
         }
       },
@@ -272,6 +276,44 @@ resource "aws_cloudwatch_dashboard" "oom" {
           metrics = [
             ["AWS/EC2", "NetworkPacketsIn", "InstanceId", aws_instance.app.id, { label = "NetworkPacketsIn" }],
             ["AWS/EC2", "NetworkPacketsOut", "InstanceId", aws_instance.app.id, { label = "NetworkPacketsOut" }]
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 18
+        width  = 12
+        height = 6
+        properties = {
+          title  = "JVM Heap/Non-Heap used vs committed (bytes)"
+          region = var.region
+          view   = "timeSeries"
+          period = 60
+          stat   = "Average"
+          metrics = [
+            ["Gilbut/App", "app.memory.heap.used.value", { label = "heap used" }],
+            ["Gilbut/App", "app.memory.heap.committed.value", { label = "heap committed" }],
+            ["Gilbut/App", "app.memory.nonheap.used.value", { label = "nonheap used" }],
+            ["Gilbut/App", "app.memory.nonheap.committed.value", { label = "nonheap committed" }]
+          ]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 18
+        width  = 12
+        height = 6
+        properties = {
+          title  = "GC pause (cumulative since JVM start)"
+          region = var.region
+          view   = "timeSeries"
+          period = 60
+          stat   = "Maximum"
+          metrics = [
+            ["Gilbut/App", "app.gc.pause.count.value", { label = "GC count" }],
+            ["Gilbut/App", "app.gc.pause.time.value", { label = "GC time (ms)", yAxis = "right" }]
           ]
         }
       }


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용

### 배경

#73에서 CloudWatch 커스텀 지표(`app.memory.heap/nonheap.*`, `app.gc.pause.*`) 미수집 문제를 해결하고 실제 데이터 유입까지 확인했다. 대시보드(`gilbut-oom-observability`)는 아직 이 새 지표를 반영하지 않은 상태였다.

### 1. 기존 위젯 갱신

- "java process RSS" 위젯에 `app.memory.heap.committed`/`app.memory.nonheap.committed` 라인을 겹쳐 그림 — `RSS − (heap.committed + nonheap.committed) = 순수 네이티브 오버헤드`를 그래프로 바로 확인 가능(로컬 실험 `실험 C`에서 손으로 계산했던 산식을 대시보드로 상시화).

### 2. 신규 위젯 2개 추가

- **"JVM Heap/Non-Heap used vs committed (bytes)"**: 힙/논힙 각각 used·committed 4줄 — 실사용량이 자체 상한(committed) 대비 얼마나 여유 있는지 상시 확인.
- **"GC pause (cumulative since JVM start)"**: GC 누적 횟수·누적 시간(ms) 2줄, count는 왼쪽/time은 오른쪽 축.

### 검증

- `terraform plan`으로 대시보드 리소스 1개만 변경됨을 확인 후 `-target`으로 apply(무관한 chatbot state drift는 여전히 배제).
- `aws cloudwatch get-dashboard`로 실제 반영된 위젯 7개(기존 5개 + 신규 2개) 직접 확인.

## 📚 추가 리팩토링 가능성

- 없음(이번 CloudWatch 관측 작업 계열의 마무리 성격).
