### PR TITLE
refactor : 논힙(Metaspace) 축소 — WebClient→RestClient 전환 및 h2 스코프 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    runtimeOnly 'com.h2database:h2'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.5'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-cloudwatch2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/backend/capstone/domain/mobility/analysis/ongoingstay/service/StayAnalysisService.java
+++ b/backend/src/main/java/backend/capstone/domain/mobility/analysis/ongoingstay/service/StayAnalysisService.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClientException;
+import org.springframework.web.client.RestClientException;
 
 @Service
 @RequiredArgsConstructor
@@ -87,7 +87,7 @@ public class StayAnalysisService {
         try {
             searchResult = kakaoSearchByCategoryService.searchByCategory(stay.getCenterLatitude(),
                 stay.getCenterLongitude(), dayRoute.getUser().getId());
-        } catch (WebClientException e) {
+        } catch (RestClientException e) {
             log.error(
                 "카카오 장소 조회에 실패했습니다. 이름 없는 장소로 저장합니다. dayRouteId={}, lat={}, lon={}",
                 dayRoute.getId(), stay.getCenterLatitude(), stay.getCenterLongitude(), e);

--- a/backend/src/main/java/backend/capstone/global/config/RestClientConfig.java
+++ b/backend/src/main/java/backend/capstone/global/config/RestClientConfig.java
@@ -2,14 +2,14 @@ package backend.capstone.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 @Configuration
-public class WebClientConfig {
+public class RestClientConfig {
 
 	@Bean
-	public WebClient.Builder webClientBuilder() {
-		return WebClient.builder();
+	public RestClient.Builder restClientBuilder() {
+		return RestClient.builder();
 	}
 
 }

--- a/backend/src/main/java/backend/capstone/integration/kakao/auth/client/KakaoAuthApiClient.java
+++ b/backend/src/main/java/backend/capstone/integration/kakao/auth/client/KakaoAuthApiClient.java
@@ -7,38 +7,36 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
+import org.springframework.web.client.RestClient;
 
 @Component
 public class KakaoAuthApiClient {
 
     private static final String USER_INFO_URI = "/v2/user/me";
 
-    private final WebClient kakaoAuthWebClient;
+    private final RestClient kakaoAuthRestClient;
 
-    public KakaoAuthApiClient(@Qualifier("kakaoAuthWebClient") WebClient kakaoAuthWebClient) {
-        this.kakaoAuthWebClient = kakaoAuthWebClient;
+    public KakaoAuthApiClient(@Qualifier("kakaoAuthRestClient") RestClient kakaoAuthRestClient) {
+        this.kakaoAuthRestClient = kakaoAuthRestClient;
     }
 
     public KakaoUserInfoResponse getUserInfo(String kakaoAccessToken) {
-        return kakaoAuthWebClient.get()
+        return kakaoAuthRestClient.get()
             .uri(USER_INFO_URI)
             .header(HttpHeaders.AUTHORIZATION, "Bearer " + kakaoAccessToken)
             .retrieve()
             .onStatus(
                 HttpStatusCode::is4xxClientError,
-                resp -> resp.bodyToMono(String.class)
-                    .flatMap(body -> Mono.error(
-                        new BusinessException(AuthErrorCode.INVALID_KAKAO_ACCESS_TOKEN)))
+                (request, response) -> {
+                    throw new BusinessException(AuthErrorCode.INVALID_KAKAO_ACCESS_TOKEN);
+                }
             )
             .onStatus(
                 HttpStatusCode::is5xxServerError,
-                resp -> resp.bodyToMono(String.class)
-                    .flatMap(
-                        body -> Mono.error(new BusinessException(AuthErrorCode.KAKAO_SERVER_ERROR)))
+                (request, response) -> {
+                    throw new BusinessException(AuthErrorCode.KAKAO_SERVER_ERROR);
+                }
             )
-            .bodyToMono(KakaoUserInfoResponse.class)
-            .block();
+            .body(KakaoUserInfoResponse.class);
     }
 }

--- a/backend/src/main/java/backend/capstone/integration/kakao/auth/config/KakaoAuthConfig.java
+++ b/backend/src/main/java/backend/capstone/integration/kakao/auth/config/KakaoAuthConfig.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 public class KakaoAuthConfig {
@@ -12,9 +12,9 @@ public class KakaoAuthConfig {
     @Value("${kakao.auth.base-url}")
     private String baseUrl;
 
-    @Bean("kakaoAuthWebClient")
-    public WebClient kakaoAuthWebClient(
-        @Qualifier("webClientBuilder") WebClient.Builder builder
+    @Bean("kakaoAuthRestClient")
+    public RestClient kakaoAuthRestClient(
+        @Qualifier("restClientBuilder") RestClient.Builder builder
     ) {
         return builder
             .baseUrl(baseUrl)

--- a/backend/src/main/java/backend/capstone/integration/kakao/local/client/KakaoLocalApiClient.java
+++ b/backend/src/main/java/backend/capstone/integration/kakao/local/client/KakaoLocalApiClient.java
@@ -6,21 +6,22 @@ import backend.capstone.integration.kakao.local.dto.KakaoSearchByKeywordResult;
 import backend.capstone.integration.kakao.local.dto.KakaoSearchByRegionCodeResult;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 @Component
 public class KakaoLocalApiClient {
 
     private static final int DEFAULT_KEYWORD_PAGE_SIZE = 10;
 
-    private final WebClient kakaoLocalWebClient;
+    private final RestClient kakaoLocalRestClient;
 
-    public KakaoLocalApiClient(@Qualifier("kakaoLocalWebClient") WebClient kakaoLocalWebClient) {
-        this.kakaoLocalWebClient = kakaoLocalWebClient;
+    public KakaoLocalApiClient(
+        @Qualifier("kakaoLocalRestClient") RestClient kakaoLocalRestClient) {
+        this.kakaoLocalRestClient = kakaoLocalRestClient;
     }
 
     public KakaoSearchByKeywordResult searchByKeyword(String query, int page) {
-        return kakaoLocalWebClient.get()
+        return kakaoLocalRestClient.get()
             .uri(uriBuilder -> uriBuilder
                 .path("/v2/local/search/keyword.json")
                 .queryParam("query", query)
@@ -28,12 +29,11 @@ public class KakaoLocalApiClient {
                 .queryParam("size", DEFAULT_KEYWORD_PAGE_SIZE)
                 .build())
             .retrieve()
-            .bodyToMono(KakaoSearchByKeywordResult.class)
-            .block();
+            .body(KakaoSearchByKeywordResult.class);
     }
 
     public KakaoSearchByCoordResult searchByCoord(double latitude, double longitude) {
-        return kakaoLocalWebClient.get()
+        return kakaoLocalRestClient.get()
             .uri(uriBuilder -> uriBuilder
                 .path("/v2/local/geo/coord2address.json")
                 .queryParam("x", longitude)
@@ -41,13 +41,12 @@ public class KakaoLocalApiClient {
                 .queryParam("input_coord", "WGS84")
                 .build())
             .retrieve()
-            .bodyToMono(KakaoSearchByCoordResult.class)
-            .block();
+            .body(KakaoSearchByCoordResult.class);
     }
 
     public KakaoSearchByRegionCodeResult searchRegionCodeByCoord(double latitude,
         double longitude) {
-        return kakaoLocalWebClient.get()
+        return kakaoLocalRestClient.get()
             .uri(uriBuilder -> uriBuilder
                 .path("/v2/local/geo/coord2regioncode.json")
                 .queryParam("x", longitude)
@@ -55,14 +54,13 @@ public class KakaoLocalApiClient {
                 .queryParam("input_coord", "WGS84")
                 .build())
             .retrieve()
-            .bodyToMono(KakaoSearchByRegionCodeResult.class)
-            .block();
+            .body(KakaoSearchByRegionCodeResult.class);
     }
 
     public KakaoSearchByCategoryResult searchByCategory(String categoryGroupCode, double latitude,
         double longitude, int radius, int size
     ) {
-        return kakaoLocalWebClient.get()
+        return kakaoLocalRestClient.get()
             .uri(uriBuilder -> uriBuilder
                 .path("/v2/local/search/category.json")
                 .queryParam("category_group_code", categoryGroupCode)
@@ -73,7 +71,6 @@ public class KakaoLocalApiClient {
                 .queryParam("size", size)
                 .build())
             .retrieve()
-            .bodyToMono(KakaoSearchByCategoryResult.class)
-            .block();
+            .body(KakaoSearchByCategoryResult.class);
     }
 }

--- a/backend/src/main/java/backend/capstone/integration/kakao/local/config/KakaoLocalConfig.java
+++ b/backend/src/main/java/backend/capstone/integration/kakao/local/config/KakaoLocalConfig.java
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 public class KakaoLocalConfig {
@@ -16,9 +16,9 @@ public class KakaoLocalConfig {
     @Value("${kakao.local.rest-api-key}")
     private String restApiKey;
 
-    @Bean("kakaoLocalWebClient")
-    public WebClient kakaoLocalWebClient(
-        @Qualifier("webClientBuilder") WebClient.Builder builder
+    @Bean("kakaoLocalRestClient")
+    public RestClient kakaoLocalRestClient(
+        @Qualifier("restClientBuilder") RestClient.Builder builder
     ) {
         return builder
             .baseUrl(baseUrl)

--- a/backend/src/main/java/backend/capstone/integration/kakao/local/service/KakaoSearchByKeywordService.java
+++ b/backend/src/main/java/backend/capstone/integration/kakao/local/service/KakaoSearchByKeywordService.java
@@ -9,7 +9,7 @@ import backend.capstone.integration.kakao.local.mapper.KakaoPlaceMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClientException;
+import org.springframework.web.client.RestClientException;
 
 @Service
 @RequiredArgsConstructor
@@ -27,7 +27,7 @@ public class KakaoSearchByKeywordService {
             }
 
             return KakaoPlaceMapper.toPlaceSearchResponse(page, result);
-        } catch (WebClientException e) {
+        } catch (RestClientException e) {
             throw new BusinessException(KakaoPlaceErrorCode.KAKAO_PLACE_SEARCH_FAILED);
         }
     }


### PR DESCRIPTION
## 🛰️ Issue Number



## 🪐 작업 내용

### 배경

`docs/tech/infra/oom-repro-evidence/production/2026-08-04-운영-힙논힙-실측.md`의 운영 실측
결과, 논힙(Metaspace+class space)이 used 기준 124.6MiB로 힙(77.1MiB)보다 크고
`MaxMetaspaceSize`가 `unlimited`라 OOM의 실질적 원인이 되고 있었다. 로드된 클래스
25,096개 중 부팅 이후 순수 증가분은 크지 않아, 런타임에 계속 늘어나는 문제가 아니라
부팅 시 얼마나 많은 클래스를 끌고 오는지가 핵심이었다.

### 1. `WebClient` → `RestClient` 전환

카카오 로컬/인증 API 클라이언트 5곳 모두 `WebClient`를 `.block()`으로 동기 호출하고
있었다. 서버 자체는 Tomcat(`spring-boot-starter-web`)이라 리액티브 논블로킹이 필요
없는데도 Reactor Netty/Reactor Core 스택 전체가 이 목적만으로 로드되고 있었다.
Spring Boot 3.2.5에 내장된 `RestClient`(추가 의존성 불필요)로 교체해 `build.gradle`에서
`spring-boot-starter-webflux` 의존성을 걷어냈다. 카카오 장소 검색/주소 변환, 카카오 로그인
사용자 정보 조회 API의 4xx/5xx 에러 매핑 동작은 그대로 유지된다.

### 2. `h2` 의존성 스코프 수정

운영 datasource는 MySQL을 가리키는데 테스트 전용 H2 드라이버가 `runtimeOnly`로 선언돼
운영 런타임 클래스패스에도 포함되고 있었다. `testRuntimeOnly`로 스코프를 좁혔다.

### 검증

- `./gradlew build`, `./gradlew test` 모두 통과
- webflux 제거 전(`3d5963d9`)과 후(현재 HEAD)를 각각 별도 `git worktree`로 체크아웃해
  동일한 로컬 조건(idle 부팅, 트래픽 없음)에서 `jcmd VM.classes`/`VM.metaspace`로 직접
  비교 측정했다. 상세 방법론과 원본 수치는
  [`docs/tech/infra/oom-repro-evidence/local/2026-08-05-webflux-제거-클래스로딩-비교.md`](../../backend/docs/tech/infra/oom-repro-evidence/local/2026-08-05-webflux-제거-클래스로딩-비교.md)
  참고.

  | 항목 | webflux 포함 | webflux 제거 | 변화 |
  |---|---:|---:|---:|
  | 로드된 클래스 총합 | 22,097개 | 21,878개 | **-219개 (-1.0%)** |
  | `reactor.netty.*`(webflux 전용) | 91개 | 0개 | **-91개 (완전 제거)** |
  | `io.netty.*` | 460개 | 201개 | **-259개** |
  | `reactor.core.*` | 344개 | 314개 | -30개 |
  | Metaspace 실사용량 | 94.13 MB | 92.48 MB | **-1.65 MB (-1.75%)** |

  남은 `io.netty.*` 201개는 `spring-boot-starter-data-redis`의 기본 드라이버
  Lettuce(Netty 기반)가 원인이며 이번 PR과 무관한 별개 사안이다(아래 "추가 리팩토링
  가능성" 참고). `io.grpc.*`/`software.amazon.awssdk.*`는 두 버전 모두 0개로,
  firebase-admin의 gRPC 전송 계층과 AWS SDK CloudWatch 클라이언트는 실제로는
  로드되지 않는 것도 함께 확인했다.
- 이 비교는 idle 부팅 1회 스냅샷이라, 실제 운영 트래픽 하에서는 절감폭이 더 클 수
  있다. 운영 배포 후 `jcmd VM.metaspace`로 재측정 예정.

## 📚 추가 리팩토링 가능성

- **springdoc(Swagger) 운영 비활성화 보류**: `SwaggerConfig`에 `@Profile` 가드가 없어
  운영에서도 OpenAPI 리플렉션 스캔이 그대로 실행된다. 다만 이 팀은 별도 개발 서버가 없어
  프론트엔드가 운영 Swagger UI를 유일한 API 문서 창구로 쓰고 있어 이번 PR 범위에서는
  제외했다. 대안으로 CI 빌드 타임에 OpenAPI 스펙을 정적 생성해 GitHub Pages 등에
  배포하는 방식(런타임엔 springdoc 자체가 로드되지 않음)을 검토할 수 있다.
- **Lettuce(Redis) → Jedis 교체 검토**: 위 검증에서 확인했듯 Netty(201개)/Reactor(314개)
  클래스가 여전히 남는데, 원인은 `spring-boot-starter-data-redis`의
  기본 드라이버 Lettuce다. 코드베이스가 `ReactiveRedisTemplate` 없이 `StringRedisTemplate`
  (동기 API)만 쓰고 있어 `JedisConnectionFactory`로 교체하는 게 API 레벨에서는 대체로
  호환된다. 다만 Jedis는 연결 풀링을 수동 튜닝해야 하고 Lettuce의 단일 연결 멀티플렉싱
  대비 커넥션 고갈 리스크가 있어, webflux 제거보다 리스크 대비 절감폭(전체 로드 클래스의
  약 3.4%)이 작다고 판단해 이번 PR에는 포함하지 않았다.
- **firebase-admin → FCM HTTP v1 REST 직접 호출 대체**: 현재 용도는 단일 메시지 타입을
  단일 토큰으로 보내는 것뿐이라 대체 여지는 있다. 다만 실측 결과 firebase-admin의 gRPC
  전송 계층(`io.grpc.*`, `grpc-netty-shaded`)은 실제로는 로드되지 않아(REST 기반 전송만
  사용) 메모리 절감 효과 자체는 크지 않을 것으로 보이며, OAuth2 토큰 발급/캐싱/갱신을
  직접 구현해야 하고 알림 발송 신뢰성에 직결되므로 우선순위는 낮다.
